### PR TITLE
Add TeamSpeak3

### DIFF
--- a/network/im/teamspeak/actions.py
+++ b/network/im/teamspeak/actions.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import get, pisitools, shelltools
+
+NoStrip = ["/opt"]
+IgnoreAutodep = True
+
+Version = get.srcVERSION()
+
+def setup():
+    shelltools.system("pwd")
+    shelltools.system("sed -i -e 's|^MS_PrintLicense$||g' TeamSpeak3-Client-linux_amd64-%s.run" % Version)
+    shelltools.system("bash ./TeamSpeak3-Client-linux_amd64-%s.run --target opt/teamspeak3" % Version)
+    shelltools.system("wget --quiet https://raw.githubusercontent.com/solus-project/3rd-party/master/network/im/teamspeak3/files/TeamSpeak3.desktop")
+
+def install():
+    pisitools.insinto("/", "opt")
+    pisitools.insinto("/usr/share/applications", "TeamSpeak3.desktop")
+    pisitools.dosym("/opt/teamspeak3/ts3client_runscript.sh", "/usr/bin/ts3client_linux_amd64")

--- a/network/im/teamspeak/files/TeamSpeak3.desktop
+++ b/network/im/teamspeak/files/TeamSpeak3.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=TeamSpeak3
+Comment=Group voice chat
+Keywords=teamspeak;voice;chat;
+Exec=ts3client_linux_amd64
+Icon=ts3client_linux_amd64
+Terminal=false
+Type=Application
+StartupNotify=true

--- a/network/im/teamspeak/pspec.xml
+++ b/network/im/teamspeak/pspec.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>teamspeak3</Name>
+        <Packager>
+            <Name>QORTEC</Name>
+            <Email>qortec.ca@gmail.com</Email>
+        </Packager>
+        <Summary>Crystal Clear Cross-Platform Voice Communication</Summary>
+        <Description>VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.</Description>
+        <License>Copyright (c) TeamSpeak Systems GmbH.</License>
+        <Archive sha1sum="87ab161865e9ba694e4862a81a9d06f6c5a7ed3b" type="binary">http://dl.4players.de/ts/releases/3.0.19.4/TeamSpeak3-Client-linux_amd64-3.0.19.4.run</Archive>
+        <BuildDependencies>
+            <Dependency>binutils</Dependency>
+            <Dependency>sed</Dependency>
+            <Dependency>wget</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <RuntimeDependencies>
+            <Dependency>gconf</Dependency>
+        </RuntimeDependencies>
+        <Name>teamspeak3</Name>
+        <Icon>ts3client_linux_amd64</Icon>
+        <Files>
+            <Path fileType="executable">/opt</Path>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="data">/usr/share/applications</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="2">
+            <Date>26-07-2016</Date>
+            <Version>3.0.19.4</Version>
+            <Comment>Update TeamSpeak3 Client to 3.0.19.4</Comment>
+            <Name>QORTEC</Name>
+            <Email>qortec.ca@gmail.com</Email>
+        </Update>
+        <Update release="1">
+            <Date>17-07-2016</Date>
+            <Version>3.0.19.3</Version>
+            <Comment>Add TeamSpeak3 Client to repositories</Comment>
+            <Name>QORTEC</Name>
+            <Email>qortec.ca@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
**TeamSpeak3**
Homepage: http://teamspeak.com
Repository:  http://dl.4players.de/ts/releases/

Possible Issues:
When installing TeamSpeak3 the normal way (running the .run file) the installer requires user intervention and the user must also accept EULA. Since requiring user input would not play nicely with the package manager, I wrote a command to remove the interactive part of the .run file.

The command can be found in ``network/im/teamspeak3/actions.py``
Line 14 ``sed -i -e 's|^MS_PrintLicense$||g' TeamSpeak3-Client-linux_amd64-%s.run``

Since the application requires you to accept the EULA (again) at first launch, I do not see a problem with stripping out the code during install time. If you feel differently fee free to reject this pull request.

Test gist: https://gist.github.com/QORTEC/d388cde33eac7aab348150f48d704848 (identical to pull request)