### PR TITLE
Update Franz + improved packaging

### DIFF
--- a/network/im/franz/actions.py
+++ b/network/im/franz/actions.py
@@ -2,14 +2,15 @@
 
 # Created for Solus Operating System
 
-from pisi.actionsapi import pisitools, shelltools
+from pisi.actionsapi import get, pisitools, shelltools
 
 NoStrip = ["/opt", "/usr"]
 IgnoreAutodep = True
 
 def setup():
     shelltools.system("pwd")
-    shelltools.system("tar xvf Franz-linux-x64-3.1.0.tgz")
+    shelltools.system("mkdir franz")
+    shelltools.system("tar xvf Franz-linux-x64-%s.tgz -C franz" % (get.srcVERSION()))
     shelltools.system("wget https://raw.githubusercontent.com/imprecision/franz-pkgbuild/master/franz.sh")
     shelltools.system("wget https://raw.githubusercontent.com/imprecision/franz-pkgbuild/master/franz.desktop")
     shelltools.system("wget https://raw.githubusercontent.com/imprecision/franz-pkgbuild/master/franz.png")
@@ -19,4 +20,4 @@ def setup():
 
 def install():
     pisitools.insinto("/", "usr")
-    pisitools.insinto("/opt/franz", "*")
+    pisitools.insinto("/opt/", "franz")

--- a/network/im/franz/pspec.xml
+++ b/network/im/franz/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>A free messaging app that combines chat and messaging services into one application</Summary>
         <Description>Franz is a free messaging app / former Emperor of Austria and combines chat and messaging services into one application. Franz currently supports Slack, WhatsApp, WeChat, HipChat, Facebook Messenger, Telegram, Google Hangouts, GroupMe, Skype and many more.</Description>
         <License>Custom</License>
-        <Archive sha1sum="18ee7c6f1079c914e54cb1ddd367e04210f59b69" type="binary">https://github.com/imprecision/franz-app/releases/download/3.1.0/Franz-linux-x64-3.1.0.tgz</Archive>
+        <Archive sha1sum="6412dfbb9803c528e808f33efb383d33cf822bde" type="binary">https://github.com/imprecision/franz-app/releases/download/3.1.1/Franz-linux-x64-3.1.1.tgz</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
             <Dependency>wget</Dependency>
@@ -25,10 +25,17 @@
         </Files>
         <RuntimeDependencies>
             <Dependency>libgtk-2</Dependency>
-            <Dependency>nodejs</Dependency>
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="2">
+            <Date>27-07-2016</Date>
+            <Version>3.1.1</Version>
+            <Comment>Update Franz to 3.1.1, remove nodejs, exclude tarball from eopkg</Comment>
+            <Name>Peter O'Connor</Name>
+            <Email>sunnyflunk@gmail.com</Email>
+        </Update>
+
         <Update release="1">
             <Date>14-07-2016</Date>
             <Version>3.1.0</Version>


### PR DESCRIPTION
Packaging withdrawl! Saw franz could be improved.

- /opt/franz/libnode.so is included with franz as par for electron apps so not needed as dep. Opens without nodejs installed
- tarball was being packaged in eopkg and 2 copies of /usr files in /opt/franz
- modified actions.py to make future updates only require pspec changes + update to 3.1.1
- learnt how to git branch!