### PR TITLE
Update Plex Media Server to 1.0.3.2461, adapt install

### DIFF
--- a/multimedia/video/component.xml
+++ b/multimedia/video/component.xml
@@ -1,0 +1,3 @@
+<PISI>
+    <Name>multimedia.video</Name>
+</PISI>

--- a/multimedia/video/plexmediaserver/actions.py
+++ b/multimedia/video/plexmediaserver/actions.py
@@ -5,15 +5,24 @@
 from pisi.actionsapi import get, pisitools, shelltools
 
 NoStrip = ["/"]
+KeepSpecial = ["python"]
 IgnoreAutodep = True
 
 def setup():
-    shelltools.system("ar xf plexmediaserver_%s-*_amd64.deb" % (get.srcVERSION()))
+    shelltools.system("ar xf plexmediaserver_%s-*_amd64.deb" % get.srcVERSION())
     shelltools.system("tar xvf data.tar.*")
+    shelltools.system("sed -i 's/x-www-browser/xdg-open/' usr/share/applications/plexmediamanager.desktop")
+    shelltools.system("wget https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/video/plexmediaserver/files/plexmediaserver.conf")
+
+    shelltools.system("wget https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/video/plexmediaserver/files/plexmediaserver.tmpfile")
+    shelltools.system("mkdir tmp")
+    shelltools.system("mv plexmediaserver.tmpfile tmp/plexmediaserver.conf")
+
+    shelltools.system("wget https://raw.githubusercontent.com/solus-project/3rd-party/master/multimedia/video/plexmediaserver/files/plexmediaserver.service")
 
 def install():
-    # root owns sandbox as it is setuid
-    pisitools.insinto("/", "etc")
-    pisitools.insinto("/", "usr")
-    pisitools.insinto("/usr/lib/sysusers.d/plexmediaserver.conf", "files/plexmediaserver.conf")
-    pisitools.insinto("/usr/lib/sysusers.d/plexmediaserver.conf", "files/plexmediaserver.conf")
+    pisitools.insinto("/opt", "usr/lib/plexmediaserver")
+    pisitools.insinto("/usr/lib64/sysusers.d", "plexmediaserver.conf")
+    pisitools.insinto("/usr/lib64/tmpfiles.d", "tmp/plexmediaserver.conf")
+    pisitools.insinto("/usr/lib64/systemd/system", "plexmediaserver.service")
+    pisitools.insinto("/usr", "usr/share")

--- a/multimedia/video/plexmediaserver/files/plexmediaserver.service
+++ b/multimedia/video/plexmediaserver/files/plexmediaserver.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Plex Media Server for Linux
+After=network.target
+
+[Service]
+Environment=LD_LIBRARY_PATH=/opt/plexmediaserver
+Environment=PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS=6
+Environment=PLEX_MEDIA_SERVER_MAX_STACK_SIZE=3000
+Environment=PLEX_MEDIA_SERVER_TMPDIR=/tmp
+Environment=PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR=/var/lib/plexmediaserver
+Environment=PLEX_MEDIA_SERVER_USER=plex
+ExecStart=/opt/plexmediaserver/Plex\x20Media\x20Server
+Type=simple
+User=plex
+Group=plex
+Restart=on-failure
+RestartSec=5
+StartLimitInterval=60s
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target

--- a/multimedia/video/plexmediaserver/files/plexmediaserver.tmpfile
+++ b/multimedia/video/plexmediaserver/files/plexmediaserver.tmpfile
@@ -1,1 +1,1 @@
-d "/var/lib/plexmediaserver/Library/Application Support" 0755 - - -
+d /var/lib/plexmediaserver 0755 plex plex -

--- a/multimedia/video/plexmediaserver/pspec.xml
+++ b/multimedia/video/plexmediaserver/pspec.xml
@@ -10,21 +10,27 @@
         <Summary>Plex Media Server</Summary>
         <Description>Plex Media Server</Description>
         <License>Custom - https://plex.tv/legal</License>
-        <Archive sha1sum="8563945f987667baf862b684a679ada687ff23d9" type="binary">https://downloads.plex.tv/plex-media-server/0.9.15.6.1714-7be11e1/plexmediaserver_0.9.15.6.1714-7be11e1_amd64.deb</Archive>
+        <Archive sha1sum="2ea9867303544b4056c2c29544cc93ae7a5981c1" type="binary">https://downloads.plex.tv/plex-media-server/1.0.3.2461-35f0caa/plexmediaserver_1.0.3.2461-35f0caa_amd64.deb</Archive>
     </Source>
 
     <Package>
         <Name>plexmediaserver</Name>
         <Files>
-            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="data">/opt/plexmediaserver</Path>
             <Path fileType="library">/usr/lib64</Path>
-            <Path fileType="executable">/usr/sbin</Path>
             <Path fileType="data">/usr/share/</Path>
-            <Path fileType="data">/etc</Path>
         </Files>
     </Package>
 
     <History>
+        <Update release="2">
+            <Date>08-29-2016</Date>
+            <Version>1.0.3.2461</Version>
+            <Comment>Update to 1.0.3.2461, adapt install</Comment>
+            <Name>Peter O'Connor</Name>
+            <Email>sunnyflunk@gmail.com</Email>
+        </Update>
+
         <Update release="1">
             <Date>03-01-2016</Date>
             <Version>0.9.15.6.1714</Version>


### PR DESCRIPTION
Has been tested by a couple of folks over on Phabricator.

Now works from not stripping .pyc 'special' files. Have adjusted file downloads in actions.py to point to solus-project/master branch for when it is merged. 

Plonked the data dir to opt to get it out the way. Uses systemd for user/directory so user required to do
`sudo systemd-tmpfiles --create` if wanted to be used prior to restarting. Is a systemd service then user operates it through the browser (has shortcut). 