### PR TITLE
Updated Franz and Vivaldi Stable

### DIFF
--- a/network/im/franz/pspec.xml
+++ b/network/im/franz/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>A free messaging app that combines chat and messaging services into one application</Summary>
         <Description>Franz is a free messaging app / former Emperor of Austria and combines chat and messaging services into one application. Franz currently supports Slack, WhatsApp, WeChat, HipChat, Facebook Messenger, Telegram, Google Hangouts, GroupMe, Skype and many more.</Description>
         <License>Custom</License>
-        <Archive sha1sum="6412dfbb9803c528e808f33efb383d33cf822bde" type="binary">https://github.com/imprecision/franz-app/releases/download/3.1.1/Franz-linux-x64-3.1.1.tgz</Archive>
+        <Archive sha1sum="a6e7aa316c376cb87d922c333a3cab4506abde2f" type="binary">https://github.com/meetfranz/franz-app/releases/download/4.0.1/Franz-linux-x64-4.0.1.tgz</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
             <Dependency>wget</Dependency>
@@ -28,6 +28,14 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="3">
+            <Date>30-08-2016</Date>
+            <Version>4.0.1</Version>
+            <Comment>Update Franz to 4.0.1</Comment>
+            <Name>Michael Keen</Name>
+            <Email>mikek1024@gmail.com</Email>
+        </Update>
+
         <Update release="2">
             <Date>27-07-2016</Date>
             <Version>3.1.1</Version>

--- a/network/im/franz/pspec.xml
+++ b/network/im/franz/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>A free messaging app that combines chat and messaging services into one application</Summary>
         <Description>Franz is a free messaging app / former Emperor of Austria and combines chat and messaging services into one application. Franz currently supports Slack, WhatsApp, WeChat, HipChat, Facebook Messenger, Telegram, Google Hangouts, GroupMe, Skype and many more.</Description>
         <License>Custom</License>
-        <Archive sha1sum="a6e7aa316c376cb87d922c333a3cab4506abde2f" type="binary">https://github.com/meetfranz/franz-app/releases/download/4.0.1/Franz-linux-x64-4.0.1.tgz</Archive>
+        <Archive sha1sum="c2fed611f77c68af89dc4c1b1c320daf200357bb" type="binary">https://github.com/meetfranz/franz-app/releases/download/4.0.2/Franz-linux-x64-4.0.2.tgz</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
             <Dependency>wget</Dependency>
@@ -28,6 +28,14 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="4">
+            <Date>31-08-2016</Date>
+            <Version>4.0.2</Version>
+            <Comment>Update Franz to 4.0.2</Comment>
+            <Name>Michael Keen</Name>
+            <Email>mikek1024@gmail.com</Email>
+        </Update>
+
         <Update release="3">
             <Date>30-08-2016</Date>
             <Version>4.0.1</Version>

--- a/network/web/browser/vivaldi-stable/pspec.xml
+++ b/network/web/browser/vivaldi-stable/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Vivaldi Web Browser</Summary>
         <Description>An advanced browser made with the power user in mind.</Description>
         <License>Custom</License>
-    <Archive sha1sum="c45a1502920a68c83389559a3d206deadf2e5df4" type="binary">https://downloads.vivaldi.com/stable/vivaldi-stable_1.3.551.30-1_amd64.deb</Archive>
+    <Archive sha1sum="347456e57ab85a0d1d393febefd21faa10ec1125" type="binary">https://downloads.vivaldi.com/stable/vivaldi-stable_1.3.551.38-1_amd64.deb</Archive>
     <BuildDependencies>
         <Dependency>binutils</Dependency>
     </BuildDependencies>
@@ -28,6 +28,14 @@
     </Package>
 
     <History>
+        <Update release="9">
+            <Date>08-30-2016</Date>
+            <Version>1.3.551.38</Version>
+            <Comment>Update to 1.3.551.38</Comment>
+            <Name>Michael Keen</Name>
+            <Email>mikek1024@gmail.com</Email>
+        </Update>
+
         <Update release="8">
             <Date>08-11-2016</Date>
             <Version>1.3.551.30</Version>


### PR DESCRIPTION
Updated Franz to 4.02 and Vivaldi stable to 1.3.551.38.