### PR TITLE
Add link to 3rd party section in the wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ Solus Operating System 3rd Party Source Repo
 
 This repo contains the build files required to create packages that cannot
 be redistributed, whether for licensing restrictions or otherwise.
+
+For more information about 3rd party applications in Solus, visit our wiki at https://wiki.solus-project.com/3rdParty.


### PR DESCRIPTION
Install instructions are not provided in this git repository for each 3rd party application. Add a link to the wiki page in the readme file so that people can easily visit the wiki for installation instructions.