### PR TITLE
Add Google Earth to 3rd-Party

### DIFF
--- a/network/web/component.xml
+++ b/network/web/component.xml
@@ -1,0 +1,3 @@
+<PISI>
+    <Name>network.web</Name>
+</PISI>

--- a/network/web/google-earth/actions.py
+++ b/network/web/google-earth/actions.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import pisitools, shelltools
+
+NoStrip = ["/opt", "/usr"]
+IgnoreAutodep = True
+
+def setup():
+    shelltools.system("ar xf google-earth-stable_current_amd64.deb")
+    shelltools.system("tar xvf data.tar.xz")
+    shelltools.system("mv opt/google/earth/free/google-earth.desktop .")
+
+def install():
+    pisitools.insinto("/", "opt")
+    pisitools.insinto("/usr", "usr/bin")
+    pisitools.insinto("/usr/share/applications", "google-earth.desktop")
+    pisitools.dosym("ld-linux-x86-64.so.2", "/lib/ld-lsb-x86-64.so.3")

--- a/network/web/google-earth/pspec.xml
+++ b/network/web/google-earth/pspec.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>google-earth</Name>
+        <Homepage>http://www.google.com/earth</Homepage>
+        <Packager>
+            <Name>Peter O'Connor</Name>
+            <Email>sunnyflunk@gmail.com</Email>
+        </Packager>
+        <Summary>3D interface for satellite imagery from Google</Summary>
+        <Description>Google Earth provides a 3D interface for viewing satellite imagery and maps.</Description>
+        <License>EULA</License>
+        <Archive sha1sum="6fffa005a6982e2e3087aae32829bb8fac6fa65d" type="binary">https://dl.google.com/dl/earth/client/current/google-earth-stable_current_amd64.deb</Archive>
+        <BuildDependencies>
+            <Dependency>binutils</Dependency>
+        </BuildDependencies>
+    </Source>
+
+    <Package>
+        <RuntimeDependencies>
+            <Dependency>fontconfig</Dependency>
+            <Dependency>libglu</Dependency>
+            <Dependency>mesalib</Dependency>
+        </RuntimeDependencies>
+        <Name>google-earth</Name>
+        <Icon>google-earth</Icon>
+        <Files>
+            <Path fileType="data">/lib</Path>
+            <Path fileType="data">/opt/google/earth</Path>
+            <Path fileType="data">/usr</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>09-06-2016</Date>
+            <Version>7.1.7.2600</Version>
+            <Comment>Add google-earth to repositories</Comment>
+            <Name>Peter O'Connor</Name>
+            <Email>sunnyflunk@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
This new release fixed everything wrong with the old one. Google login works, it doesn't crash frequently on startup. They render one of the layers a bit strangely, but otherwise seems like a solid release. 

Built against a random glibc location so made a symlink for /lib/ld-lsb-x86-64.so.3 to make it work.

Resolves https://dev.solus-project.com/T3