### PR TITLE
Google Chrome: Install fallback icons

### DIFF
--- a/network/web/browser/google-chrome-beta/actions.py
+++ b/network/web/browser/google-chrome-beta/actions.py
@@ -20,5 +20,9 @@ def install():
     shelltools.system("chown root:root opt/google/chrome-beta/chrome-sandbox")
     # ensure setuid
     shelltools.system("chmod 4755 opt/google/chrome-beta/chrome-sandbox")
+
     pisitools.insinto("/", "opt")
     pisitools.insinto("/", "usr")
+
+    for i in ["16", "22", "24", "32", "48", "64", "128", "256"]:
+        pisitools.insinto("/usr/share/icons/hicolor/%sx%s/apps" % (i,i), "opt/google/chrome-beta/product_logo_%s.png" % i, "google-chrome-beta.png")

--- a/network/web/browser/google-chrome-beta/pspec.xml
+++ b/network/web/browser/google-chrome-beta/pspec.xml
@@ -26,6 +26,7 @@
         <Files>
             <Path fileType="executable">/usr/bin</Path>
             <Path fileType="data">/usr/share/applications</Path>
+            <Path fileType="data">/usr/share/icons</Path>
             <Path fileType="doc">/usr/share/doc</Path>
             <Path fileType="man">/usr/share/man</Path>
             <Path fileType="data">/usr/share/gnome-control-center</Path>
@@ -39,6 +40,14 @@
     </Package>
 
     <History>
+        <Update release="79">
+            <Date>10-19-2016</Date>
+            <Version>54.0.2840.59</Version>
+            <Comment>Install fallback icons</Comment>
+            <Name>Federico Damián Schonborn</Name>
+            <Email>federico.d.schonborn@gmail.com</Email>
+        </Update>
+
         <Update release="78">
             <Date>10-13-2016</Date>
             <Version>54.0.2840.59</Version>

--- a/network/web/browser/google-chrome-stable/actions.py
+++ b/network/web/browser/google-chrome-stable/actions.py
@@ -20,5 +20,9 @@ def install():
     shelltools.system("chown root:root opt/google/chrome/chrome-sandbox")
     # ensure setuid
     shelltools.system("chmod 4755 opt/google/chrome/chrome-sandbox")
+
     pisitools.insinto("/", "opt")
     pisitools.insinto("/", "usr")
+
+    for i in ["16", "22", "24", "32", "48", "64", "128", "256"]:
+        pisitools.insinto("/usr/share/icons/hicolor/%sx%s/apps" % (i,i), "opt/google/chrome/product_logo_%s.png" % i, "google-chrome.png")

--- a/network/web/browser/google-chrome-stable/pspec.xml
+++ b/network/web/browser/google-chrome-stable/pspec.xml
@@ -31,6 +31,7 @@
         <Files>
             <Path fileType="executable">/usr/bin</Path>
             <Path fileType="data">/usr/share/applications</Path>
+            <Path fileType="data">/usr/share/icons</Path>
             <Path fileType="doc">/usr/share/doc</Path>
             <Path fileType="man">/usr/share/man</Path>
             <Path fileType="data">/usr/share/gnome-control-center</Path>
@@ -40,6 +41,14 @@
     </Package>
 
     <History>
+        <Update release="78">
+            <Date>10-19-2016</Date>
+            <Version>54.0.2840.59</Version>
+            <Comment>Install fallback icons</Comment>
+            <Name>Federico Damián Schonborn</Name>
+            <Email>federico.d.schonborn@gmail.com</Email>
+        </Update>
+
         <Update release="77">
             <Date>10-13-2016</Date>
             <Version>54.0.2840.59</Version>

--- a/network/web/browser/google-chrome-unstable/actions.py
+++ b/network/web/browser/google-chrome-unstable/actions.py
@@ -20,5 +20,9 @@ def install():
     shelltools.system("chown root:root opt/google/chrome-unstable/chrome-sandbox")
     # ensure setuid
     shelltools.system("chmod 4755 opt/google/chrome-unstable/chrome-sandbox")
+
     pisitools.insinto("/", "opt")
     pisitools.insinto("/", "usr")
+
+    for i in ["16", "22", "24", "32", "48", "64", "128", "256"]:
+        pisitools.insinto("/usr/share/icons/hicolor/%sx%s/apps" % (i,i), "opt/google/chrome-unstable/product_logo_%s.png" % i, "google-chrome-unstable.png")

--- a/network/web/browser/google-chrome-unstable/pspec.xml
+++ b/network/web/browser/google-chrome-unstable/pspec.xml
@@ -31,6 +31,7 @@
         <Files>
             <Path fileType="executable">/usr/bin</Path>
             <Path fileType="data">/usr/share/applications</Path>
+            <Path fileType="data">/usr/share/icons</Path>
             <Path fileType="doc">/usr/share/doc</Path>
             <Path fileType="man">/usr/share/man</Path>
             <Path fileType="data">/usr/share/gnome-control-center</Path>
@@ -40,6 +41,14 @@
     </Package>
 
     <History>
+        <Update release="64">
+            <Date>10-19-2016</Date>
+            <Version>55.0.2883.18</Version>
+            <Comment>Install fallback icons</Comment>
+            <Name>Federico Damián Schonborn</Name>
+            <Email>federico.d.schonborn@gmail.com</Email>
+        </Update>
+
         <Update release="63">
             <Date>10-19-2016</Date>
             <Version>55.0.2883.18</Version>


### PR DESCRIPTION
Copy-paste from Vivaldi spec to install the fallback icons for crazy people using Adwaita or icon themes without an icon for Chrome (as Breeze)

![captura de pantalla de 2016-10-19 09-13-55](https://cloud.githubusercontent.com/assets/20542037/19518219/62ae68ae-95dc-11e6-9b49-4927f91135a2.png)
