### PR TITLE
Update Google Chrome Unstable to 56.0.2897.0

### DIFF
--- a/network/web/browser/google-chrome-unstable/pspec.xml
+++ b/network/web/browser/google-chrome-unstable/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>The web browser from Google</Summary>
         <Description> Google Chrome is a browser that combines a minimal design with sophisticated technology to make the web faster, safer, and easier.</Description>
         <License>EULA</License>
-        <Archive sha1sum="e64c0100a930052c620cbbfff4b5e3340822f81b" type="binary">http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_55.0.2883.18-1_amd64.deb</Archive>
+        <Archive sha1sum="6684497dd53248085a2fa199faabc97899c29669" type="binary">http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-unstable/google-chrome-unstable_56.0.2897.0-1_amd64.deb</Archive>
 
         <BuildDependencies>
             <Dependency>libxscrnsaver</Dependency>
@@ -41,6 +41,14 @@
     </Package>
 
     <History>
+        <Update release="65">
+            <Date>10-22-2016</Date>
+            <Version>56.0.2897.0</Version>
+            <Comment>Update to 56.0.2897.0</Comment>
+            <Name>Daniel Pinto</Name>
+            <Email>danielpinto8zz6@gmail.com</Email>
+        </Update>
+        
         <Update release="64">
             <Date>10-19-2016</Date>
             <Version>55.0.2883.18</Version>


### PR DESCRIPTION
The dev channel has been updated 56.0.2897.0 for Linux.

https://googlechromereleases.blogspot.pt/2016/10/dev-channel-update-for-desktop_21.html