### PR TITLE
Insync

### DIFF
--- a/network/download/insync/actions.py
+++ b/network/download/insync/actions.py
@@ -12,7 +12,7 @@ def setup():
     shelltools.system("tar xvf data.tar.gz")
 
     # enable status indicators the in nautilus file manager; requires the package
-    #    nautilus-python to be installed (should be installed automatically as 
+    #    nautilus-python to be installed (should be installed automatically as
     #    a dependency from pspec.xml)
     shelltools.system("ar xf insync-nautilus_{}-precise_all.deb".format(get.srcVERSION() ) )
     shelltools.system("tar xvf data.tar.gz")

--- a/network/download/insync/actions.py
+++ b/network/download/insync/actions.py
@@ -5,6 +5,7 @@
 from pisi.actionsapi import pisitools, shelltools, get
 
 NoStrip = ["/etc", "/usr"]
+KeepSpecial = ["python"]
 
 
 def setup():

--- a/network/download/insync/actions.py
+++ b/network/download/insync/actions.py
@@ -8,7 +8,7 @@ NoStrip = ["/etc", "/usr"]
 
 
 def setup():
-    shelltools.system("ar xf insync_{}-trusty_amd64.deb".format(get.srcVERSION()) )
+    shelltools.system("ar xf insync_{}-trusty_amd64.deb".format(get.srcVERSION() ) )
     shelltools.system("tar xvf data.tar.gz")
 
     # enable status indicators the in nautilus file manager; requires the package

--- a/network/download/insync/actions.py
+++ b/network/download/insync/actions.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import pisitools, shelltools
+
+NoStrip = ["/etc", "/usr"]
+
+
+def setup():
+    shelltools.system("ar xf insync_1.3.12.36116-trusty_amd64.deb")
+    shelltools.system("tar xvf data.tar.gz")
+    shelltools.system("rmdir usr/share/icons/hicolor/64x64/emblems")
+
+def install():
+    pisitools.insinto("/", "etc")
+    pisitools.insinto("/", "usr")
+        

--- a/network/download/insync/actions.py
+++ b/network/download/insync/actions.py
@@ -2,17 +2,24 @@
 
 # Created For Solus Operating System
 
-from pisi.actionsapi import pisitools, shelltools
+from pisi.actionsapi import pisitools, shelltools, get
 
 NoStrip = ["/etc", "/usr"]
 
 
 def setup():
-    shelltools.system("ar xf insync_1.3.12.36116-trusty_amd64.deb")
+    shelltools.system("ar xf insync_{}-trusty_amd64.deb".format(get.srcVERSION()) )
     shelltools.system("tar xvf data.tar.gz")
-    shelltools.system("rmdir usr/share/icons/hicolor/64x64/emblems")
+
+    # enable status indicators the in nautilus file manager; requires the package
+    #    nautilus-python to be installed (should be installed automatically as 
+    #    a dependency from pspec.xml)
+    shelltools.system("ar xf insync-nautilus_{}-precise_all.deb".format(get.srcVERSION() ) )
+    shelltools.system("tar xvf data.tar.gz")
+
+    # a similar package exists for the caja file manager but requires python-caja
+    #    to be packaged for Solus first
 
 def install():
     pisitools.insinto("/", "etc")
     pisitools.insinto("/", "usr")
-        

--- a/network/download/insync/pspec.xml
+++ b/network/download/insync/pspec.xml
@@ -12,15 +12,15 @@
         <License>Custom - https://www.insynchq.com/terms</License>
         <Archive sha1sum="2b9aba91129f0c3f88a70efecad1e79205ea2298" type="binary">http://s.insynchq.com/builds/insync_1.3.12.36116-trusty_amd64.deb</Archive>
 	<Archive sha1sum="6b0b7e253e702367379fa75ea52bd79cdfbaebbb" type="binary">http://s.insynchq.com/builds/insync-nautilus_1.3.12.36116-precise_all.deb</Archive>
-        <BuildDependencies>
-	    <Dependency>nautilus-python</Dependency>
-        </BuildDependencies>
     </Source>
     <Package>
         <Name>insync</Name>
         <Files>
             <Path fileType="*">/</Path>
         </Files>
+    <RuntimeDependencies>
+        <Dependency>nautilus-python</Dependency>
+    </RuntimeDependencies>
     </Package>
     <History>
         <Update release="1">

--- a/network/download/insync/pspec.xml
+++ b/network/download/insync/pspec.xml
@@ -18,9 +18,9 @@
         <Files>
             <Path fileType="*">/</Path>
         </Files>
-    <RuntimeDependencies>
-        <Dependency>nautilus-python</Dependency>
-    </RuntimeDependencies>
+        <RuntimeDependencies>
+            <Dependency>nautilus-python</Dependency>
+        </RuntimeDependencies>
     </Package>
     <History>
         <Update release="1">

--- a/network/download/insync/pspec.xml
+++ b/network/download/insync/pspec.xml
@@ -11,20 +11,21 @@
         <Description>Insync extends Drive's web functionality to your desktop by integrating tightly with Windows, Mac and Linux so you can get work done.</Description>
         <License>Custom - https://www.insynchq.com/terms</License>
         <Archive sha1sum="2b9aba91129f0c3f88a70efecad1e79205ea2298" type="binary">http://s.insynchq.com/builds/insync_1.3.12.36116-trusty_amd64.deb</Archive>
-    
+	<Archive sha1sum="6b0b7e253e702367379fa75ea52bd79cdfbaebbb" type="binary">http://s.insynchq.com/builds/insync-nautilus_1.3.12.36116-precise_all.deb</Archive>
+    <BuildDependencies>
+	    <Dependency>nautilus-python</Dependency>
+    </BuildDependencies>
     </Source>
-
     <Package>
         <Name>insync</Name>
         <Files>
             <Path fileType="*">/</Path>
         </Files>
     </Package>
-
     <History>
         <Update release="1">
             <Date>10-29-2016</Date>
-            <Version>1.3.12</Version>
+            <Version>1.3.12.36116</Version>
             <Comment>initial build</Comment>
             <Name>Mitchell Fossen</Name>
             <Email>msfossen@gmail.com</Email>

--- a/network/download/insync/pspec.xml
+++ b/network/download/insync/pspec.xml
@@ -12,9 +12,9 @@
         <License>Custom - https://www.insynchq.com/terms</License>
         <Archive sha1sum="2b9aba91129f0c3f88a70efecad1e79205ea2298" type="binary">http://s.insynchq.com/builds/insync_1.3.12.36116-trusty_amd64.deb</Archive>
 	<Archive sha1sum="6b0b7e253e702367379fa75ea52bd79cdfbaebbb" type="binary">http://s.insynchq.com/builds/insync-nautilus_1.3.12.36116-precise_all.deb</Archive>
-    <BuildDependencies>
+        <BuildDependencies>
 	    <Dependency>nautilus-python</Dependency>
-    </BuildDependencies>
+        </BuildDependencies>
     </Source>
     <Package>
         <Name>insync</Name>

--- a/network/download/insync/pspec.xml
+++ b/network/download/insync/pspec.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>insync</Name>
+        <Packager>
+            <Name>Mitchell Fossen</Name>
+            <Email>msfossen@gmail.com</Email>
+        </Packager>
+        <Summary>The most powerful Google Drive client ever built</Summary>
+        <Description>Insync extends Drive's web functionality to your desktop by integrating tightly with Windows, Mac and Linux so you can get work done.</Description>
+        <License>Custom - https://www.insynchq.com/terms</License>
+        <Archive sha1sum="2b9aba91129f0c3f88a70efecad1e79205ea2298" type="binary">http://s.insynchq.com/builds/insync_1.3.12.36116-trusty_amd64.deb</Archive>
+    
+    </Source>
+
+    <Package>
+        <Name>insync</Name>
+        <Files>
+            <Path fileType="*">/</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>10-29-2016</Date>
+            <Version>1.3.12</Version>
+            <Comment>initial build</Comment>
+            <Name>Mitchell Fossen</Name>
+            <Email>msfossen@gmail.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
Initial working Insync client. Also installs Nautilus integration so you can see the sync status of files and folders. Tested working under both Budgie and MATE.

Caja integration exists, but requires  python-caja to be packaged for Solus first.

I have a few questions as well:
1) Nautilus integration requires that nautilus-python is installed. It's a dependency in the pspec.xml file so will be installed automatically, however if a person uses a different file manager (like Caja) then it's a wasted installation. How should that be handled?

2) Is there a better way to generate the pspec.xml file, or is editing it by hand the proper method?

Let me know if there are changes I should make, thanks for looking this over.
