### PR TITLE
Update vivaldi-stable to 1.4.589.38, removed symlink function from ac…

### DIFF
--- a/network/web/browser/vivaldi-stable/actions.py
+++ b/network/web/browser/vivaldi-stable/actions.py
@@ -14,7 +14,6 @@ def setup():
 def install():
     pisitools.insinto("/", "opt")
     pisitools.insinto("/", "usr")
-    pisitools.dosym("/opt/vivaldi/vivaldi", "/usr/bin/vivaldi-stable")
     for i in ["16", "22", "24", "32", "48", "64", "128", "256"]:
         pisitools.insinto("/usr/share/icons/hicolor/%sx%s/apps" % (i,i), "opt/vivaldi/product_logo_%s.png" % i, "vivaldi.png")
     

--- a/network/web/browser/vivaldi-stable/pspec.xml
+++ b/network/web/browser/vivaldi-stable/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Vivaldi Web Browser</Summary>
         <Description>An advanced browser made with the power user in mind.</Description>
         <License>Custom</License>
-    <Archive sha1sum="98054f4b5aab3ff3a3aebf9712c21b0350e89f78" type="binary">https://downloads.vivaldi.com/stable/vivaldi-stable_1.4.589.11-1_amd64.deb</Archive>
+    <Archive sha1sum="4a3e69db2849159a978ac8ee9382ac7857cc47c0" type="binary">https://downloads.vivaldi.com/stable/vivaldi-stable_1.4.589.38-1_amd64.deb</Archive>
     <BuildDependencies>
         <Dependency>binutils</Dependency>
     </BuildDependencies>
@@ -28,6 +28,14 @@
     </Package>
 
     <History>
+        <Update release="10">
+            <Date>11-03-2016</Date>
+            <Version>1.4.589.38</Version>
+            <Comment>Update to 1.4.589.38</Comment>
+            <Name>Shawn W Dunn</Name>
+            <Email>sfalken@cloverleaf-linux.org</Email>
+        </Update>
+
         <Update release="9">
             <Date>09-08-2016</Date>
             <Version>1.4.589.11</Version>


### PR DESCRIPTION
…tions.py, no longer needed

The symlink is already included in the prebuilt .deb

Signed-off-by: Shawn W Dunn <sfalken@cloverleaf-linux.org>