### PR TITLE
Initial inclusion of Adobe Flash NPAPI and PPAPI.

### DIFF
--- a/multimedia/video/flash-player-npapi/actions.py
+++ b/multimedia/video/flash-player-npapi/actions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import get, pisitools, shelltools
+
+NoStrip = ["/opt", "/usr"]
+IgnoreAutodep = True
+
+# Should not change.
+Suffix = "-1"
+
+def setup():
+    shelltools.system("tar xvf flash_player_npapi_linux.x86_64.tar.gz")
+
+def install():
+    pisitools.insinto("/usr/bin", "usr/bin/flash-player-properties")
+    pisitools.insinto("/usr/share/applications", "usr/share/applications/flash-player-properties.desktop")
+    pisitools.insinto("/usr/lib/mozilla/plugins", "libflashplayer.so")
+
+    for i in ["16", "22", "24", "32", "48"]:
+        pisitools.insinto("/usr/share/icons/hicolor/%sx%s/apps" % (i,i), "usr/share/icons/hicolor/%sx%s/apps/flash-player-properties.png" % (i,i))

--- a/multimedia/video/flash-player-npapi/pspec.xml
+++ b/multimedia/video/flash-player-npapi/pspec.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>flash-player-npapi</Name>
+        <Homepage>http://www.adobe.com/software/flash/about/</Homepage>
+        <Packager>
+            <Name>Joshua Strobl</Name>
+            <Email>joshua@stroblindustries.com</Email>
+        </Packager>
+        <Summary>Adobe Flash Player (NPAPI)</Summary>
+        <Description>Adobe Flash Player (NPAPI).</Description>
+        <License>EULA</License>
+        <Archive sha1sum="3bb39905346d71d2212626ca21d4531627f7d76e" type="binary">https://fpdownload.adobe.com/get/flashplayer/pdc/24.0.0.186/flash_player_npapi_linux.x86_64.tar.gz</Archive>
+    </Source>
+    <Package>
+        <Name>flash-player-npapi</Name>
+        <Icon>flash-player</Icon>
+        <Files>
+            <Path fileType="executable">/usr/bin</Path>
+            <Path fileType="library">/usr/lib</Path>
+            <Path fileType="data">/usr/share/applications</Path>
+            <Path fileType="data">/usr/share/icons</Path>
+            <Path fileType="data">/usr/share/pixmaps</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>12-14-2016</Date>
+            <Version>24.0.0.186</Version>
+            <Comment>Initial inclusion of Adobe Flash (NPAPI) in Third Party</Comment>
+            <Name>Joshua Strobl</Name>
+            <Email>joshua@stroblindustries.com</Email>
+        </Update>
+    </History>
+</PISI>

--- a/multimedia/video/flash-player-ppapi/actions.py
+++ b/multimedia/video/flash-player-ppapi/actions.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python
+
+# Created For Solus Operating System
+
+from pisi.actionsapi import get, pisitools, shelltools
+
+NoStrip = ["/opt", "/usr"]
+IgnoreAutodep = True
+
+# Should not change.
+Suffix = "-1"
+
+def setup():
+    shelltools.system("tar xvf flash_player_ppapi_linux.x86_64.tar.gz")
+
+def install():
+    pisitools.insinto("/opt/google/chrome/PepperFlash", "libpepflashplayer.so")

--- a/multimedia/video/flash-player-ppapi/pspec.xml
+++ b/multimedia/video/flash-player-ppapi/pspec.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
+<PISI>
+    <Source>
+        <Name>flash-player-ppapi</Name>
+        <Homepage>http://www.adobe.com/software/flash/about/</Homepage>
+        <Packager>
+            <Name>Joshua Strobl</Name>
+            <Email>joshua@stroblindustries.com</Email>
+        </Packager>
+        <Summary>Adobe Flash Player (PPAPI)</Summary>
+        <Description>Adobe Flash Player (PPAPI).</Description>
+        <License>EULA</License>
+        <Archive sha1sum="9ddc7f64bd74088ffa43c9f4730c006111e1c522" type="binary">https://fpdownload.adobe.com/get/flashplayer/pdc/24.0.0.186/flash_player_ppapi_linux.x86_64.tar.gz</Archive>
+    </Source>
+    <Package>
+        <Name>flash-player-ppapi</Name>
+        <Icon>flash-player</Icon>
+        <Files>
+            <Path fileType="library">/opt</Path>
+        </Files>
+    </Package>
+
+    <History>
+        <Update release="1">
+            <Date>12-14-2016</Date>
+            <Version>24.0.0.186</Version>
+            <Comment>Initial inclusion of Adobe Flash (PPAPI) in Third Party</Comment>
+            <Name>Joshua Strobl</Name>
+            <Email>joshua@stroblindustries.com</Email>
+        </Update>
+    </History>
+</PISI>


### PR DESCRIPTION
As Adobe has since changed the distribution policy of Adobe Flash, this replaces `flash-player-nonfree` from the Solus repositories. `-nonfree` is referred to as NPAPI, whereas PPAPI is typically referred to as "pepper flash" and can be leveraged by Vivaldi without requiring the installation of Chrome.