### PR TITLE
Updates PyCharm to 2016.3.1

### DIFF
--- a/programming/pycharm/actions.py
+++ b/programming/pycharm/actions.py
@@ -4,9 +4,9 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-
+Version =  get.srcVERSION()
 
 def install():
-    shutil.rmtree("pycharm-2016.2.3/jre")
-    pisitools.insinto("/opt/pycharm", "pycharm-2016.2.3/*")
+    shutil.rmtree("pycharm-%s/jre" % Version)
+    pisitools.insinto("/opt/pycharm", "pycharm-%s/*" % Version)
     pisitools.dosym("/opt/pycharm/bin/pycharm.sh", "/usr/bin/pycharm")

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="9c8dbd852747a7d161a80536143119c0c81fcdc3">https://download.jetbrains.com/python/pycharm-professional-2016.2.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="c3565310483b54da6e67fc88febdef379e8dd00a">https://download.jetbrains.com/python/pycharm-professional-2016.3.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="3">
+            <Date>2016-12-25</Date>
+            <Version>2016.3.1</Version>
+            <Comment>Updated to 2016.3.1</Comment>
+            <Name>Niklas Heer</Name>
+            <Email>me@nheer.io</Email>
+        </Update>
         <Update release="2">
             <Date>2016-10-16</Date>
             <Version>2016.2.3</Version>


### PR DESCRIPTION
This PR updates PyCharm to the newest 2016.3.1 release.
(this time I thought I can use the "Version"-method because the folder follows that standard)