### PR TITLE
Updates PyCharm CE to 2016.3.1

### DIFF
--- a/programming/pycharm-ce/actions.py
+++ b/programming/pycharm-ce/actions.py
@@ -4,9 +4,9 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-
+Version =  get.srcVERSION()
 
 def install():
-    shutil.rmtree("pycharm-community-2016.2.3/jre")
-    pisitools.insinto("/opt/pycharm-ce", "pycharm-community-2016.2.3/*")
+    shutil.rmtree("pycharm-community-%s/jre" % Version)
+    pisitools.insinto("/opt/pycharm-ce", "pycharm-community-%s/*" % Version)
     pisitools.dosym("/opt/pycharm-ce/bin/pycharm.sh", "/usr/bin/pycharm-ce")

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="71c2f0c8ec2ded03db3a69445bc1b1da9042c2dc">http://download.jetbrains.com/python/pycharm-community-2016.2.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="50cede73df8f91ac87aff1e1f91754264198670c">http://download.jetbrains.com/python/pycharm-community-2016.3.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="2">
+            <Date>2016-12-25</Date>
+            <Version>2016.3.1</Version>
+            <Comment>Updated to 2016.3.1</Comment>
+            <Name>Niklas Heer</Name>
+            <Email>me@nheer.io</Email>
+        </Update>
         <Update release="1">
             <Date>2016-10-31</Date>
             <Version>2016.2.3</Version>


### PR DESCRIPTION
This PR updates PyCharm Community Edition to the newest 2016.3.1 release.
I also added the "Version"-method to this one.