### PR TITLE
Updates DataGrip to 2016.3.1

### DIFF
--- a/programming/datagrip/actions.py
+++ b/programming/datagrip/actions.py
@@ -4,9 +4,9 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-
+Version =  get.srcVERSION()
 
 def install():
-    shutil.rmtree("DataGrip-2016.2.5/jre")
-    pisitools.insinto("/opt/datagrip", "DataGrip-2016.2.5/*")
+    shutil.rmtree("DataGrip-%s/jre" % Version)
+    pisitools.insinto("/opt/datagrip", "DataGrip-%s/*" % Version)
     pisitools.dosym("/opt/datagrip/bin/datagrip.sh", "/usr/bin/datagrip")

--- a/programming/datagrip/files/datagrip.desktop
+++ b/programming/datagrip/files/datagrip.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Type=Application
 Name=DataGrip
-Icon=/opt/datagrip/bin/product.png
+Icon=/opt/datagrip/bin/datagrip.png
 Exec=datagrip %f
 Comment=The Drive to Develop
 Categories=Development;IDE;

--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="9dc5deddcddd67718bd8651a373a73d32e696ded">https://download.jetbrains.com/datagrip/datagrip-2016.2.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="5194da8cfae65dabcddf36b911ca5237285c82bf">https://download.jetbrains.com/datagrip/datagrip-2016.3.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="3">
+            <Date>2016-12-25</Date>
+            <Version>2016.3.1</Version>
+            <Comment>Updated to 2016.3.1</Comment>
+            <Name>Niklas Heer</Name>
+            <Email>me@nheer.io</Email>
+        </Update>
         <Update release="2">
             <Date>2016-10-16</Date>
             <Version>2016.2.5</Version>


### PR DESCRIPTION
This PR updates DataGrip to the newest 2016.3.1 release.

I think now all Jetbrains products should be up to date. :D 