### PR TITLE
Add Depedencies to Franz

### DIFF
--- a/network/im/franz/pspec.xml
+++ b/network/im/franz/pspec.xml
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="7">
+            <Date>10-02-2017</Date>
+            <Version>4.0.4</Version>
+            <Comment>Add dependencies to libxscrnsaver and gconf</Comment>
+            <Name>Sebastian Würl</Name>
+            <Email>bastiwuerl@gmail.com</Email>
+        </Update>
         <Update release="6">
             <Date>13-09-2016</Date>
             <Version>4.0.4</Version>

--- a/network/im/franz/pspec.xml
+++ b/network/im/franz/pspec.xml
@@ -25,6 +25,8 @@
         </Files>
         <RuntimeDependencies>
             <Dependency>libgtk-2</Dependency>
+            <Dependency>libxscrnsaver</Dependency>
+            <Dependency>gconf</Dependency>
         </RuntimeDependencies>
     </Package>
     <History>


### PR DESCRIPTION
Franz needs libXss.so.1 and libgconf-2.so.4
Reproduce:
 - uninstall libxscrnsaver and/or gconf (not installed in stock solus)
 - install franz
 - launch 'franz' in terminal