### PR TITLE
Spideroak depends on binutils

### DIFF
--- a/network/download/spideroak/pspec.xml
+++ b/network/download/spideroak/pspec.xml
@@ -11,14 +11,14 @@
         <Description>Spideroak one is a reliable, private backup for everything in your life.</Description>
         <License>Custom - https://spideroak.com/policy/terms-of-use</License>
         <Archive sha1sum="81e7e03038169062f7eb223b6b1e5761b5e5db69" type="binary">https://spideroak.com/getbuild?platform=ubuntu&amp;arch=x86_64</Archive>
-    
+
     <BuildDependencies>
 		<Dependency>glib2</Dependency>
 		<Dependency>fontconfig</Dependency>
 		<Dependency>libnih</Dependency>
-	    	<Dependency>binutils</Dependency>
+		<Dependency>binutils</Dependency>
     </BuildDependencies>
-    
+
     </Source>
 
     <Package>

--- a/network/download/spideroak/pspec.xml
+++ b/network/download/spideroak/pspec.xml
@@ -16,6 +16,7 @@
 		<Dependency>glib2</Dependency>
 		<Dependency>fontconfig</Dependency>
 		<Dependency>libnih</Dependency>
+	    	<Dependency>binutils</Dependency>
     </BuildDependencies>
     
     </Source>


### PR DESCRIPTION
## Rational of the change
- Spideroak install script uses `ar` and should therefor depend on `binutils`

## Why is this change necessary?
- It fixes issue https://github.com/solus-project/3rd-party/issues/134

## How have I tested this change?
- On local fresh install of Solus successfully installed Spideroak from the fork