### PR TITLE
Update Webstorm to Version 2017.1.4

### DIFF
--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 
 
 def install():
-    shutil.rmtree("WebStorm-171.4249.40/jre64")
-    pisitools.insinto("/opt/webstorm", "WebStorm-171.4249.40/*")
+    shutil.rmtree("WebStorm-171.4694.29/jre64")
+    pisitools.insinto("/opt/webstorm", "WebStorm-171.4694.29/*")
     pisitools.dosym("/opt/webstorm/bin/webstorm.sh", "/usr/bin/webstorm")

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="908ed21b2f7611b47aec9ee39b2b2fbb6770133f">https://download.jetbrains.com/webstorm/WebStorm-2017.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="2839cb0d40e5b8b4c4179588c1af089811bb2bea">https://download.jetbrains.com/webstorm/WebStorm-2017.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="6">
+            <Date>2017-06-28</Date>
+            <Version>2017.1.4</Version>
+            <Comment>Updated to 2017.1.4</Comment>
+            <Name>Ricky Grassmuck</Name>
+            <Email>rigrassm@gmail.com</Email>
+        </Update>
         <Update release="5">
             <Date>2017-04-27</Date>
             <Version>2017.1.2</Version>


### PR DESCRIPTION
Pull request updates Webstorm to the latest Webstorm release.

Tested personally by building from my fork and installing the resulting eopkg with no issues.