### PR TITLE
Update skype to 5.4.0.1

### DIFF
--- a/network/im/skype/pspec.xml
+++ b/network/im/skype/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Skype keeps the world talking, for free.</Summary>
         <Description>Skype keeps you together. Call, message and share with others.</Description>
         <License>Copyright (c) 2016 Skype and/or Microsoft</License>
-        <Archive sha1sum="3baf17d2bb675d3063c4998a83ec64b28cb2eda5" type="binary">https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_5.3.0.1_amd64.deb</Archive>
+        <Archive sha1sum="b14605240ce2744888ffd5239ebd4e6fbd1a6fcf" type="binary">https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_5.4.0.1_amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -35,6 +35,14 @@
     </Package>
     
     <History>
+        <Update release="22">
+            <Date>07-18-2017</Date>
+            <Version>5.4.0.1</Version>
+            <Comment>Update Skype to 5.4.0.1</Comment>
+            <Name>Pierre-Yves</Name>
+            <Email>pyu@riseup.net</Email>
+        </Update>
+
         <Update release="21">
             <Date>06-04-2017</Date>
             <Version>5.3.0.1</Version>


### PR DESCRIPTION
What’s New:
- Enabled the Group video calling
- Updated to Electron 1.7.4 for performance and security improvements
- Fixed the Skype Update repository keys
- Bugfixes and improvements

Signed-off-by: Pierre-Yves <pyu@riseup.net>