### PR TITLE
update slack to 2.8.0

### DIFF
--- a/network/im/slack-desktop/pspec.xml
+++ b/network/im/slack-desktop/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Team communication for the 21st century.</Summary>
         <Description>Team communication for the 21st century.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="f97172bead24761f1c119b9e6cb305ea607ba20e" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.7.1-amd64.deb</Archive>
+        <Archive sha1sum="c8c301633866db3e7b986061b4288c902d2c954f" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.8.0-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -37,6 +37,13 @@
     </Package>
 
     <History>
+        <Update release="11">
+            <Date>09-13-2017</Date>
+            <Version>2.8.0</Version>
+            <Comment>Update to 2.8.0</Comment>
+            <Name>Matthew Critchlow</Name>
+            <Email>matt.critchlow@gmail.com</Email>
+        </Update>
         <Update release="10">
             <Date>08-17-2017</Date>
             <Version>2.7.1</Version>


### PR DESCRIPTION
Full release notes: https://slack.com/release-notes/linux