### PR TITLE
update slack to 2.8.1

### DIFF
--- a/network/im/slack-desktop/pspec.xml
+++ b/network/im/slack-desktop/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Team communication for the 21st century.</Summary>
         <Description>Team communication for the 21st century.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="c8c301633866db3e7b986061b4288c902d2c954f" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.8.0-amd64.deb</Archive>
+        <Archive sha1sum="d1711b061c01e111dce0ee4fa5e3031d9b38381b" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.8.1-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -37,6 +37,13 @@
     </Package>
 
     <History>
+        <Update release="12">
+            <Date>10-03-2017</Date>
+            <Version>2.8.1</Version>
+            <Comment>Update to 2.8.1</Comment>
+            <Name>Matthew Critchlow</Name>
+            <Email>matt.critchlow@gmail.com</Email>
+        </Update>
         <Update release="11">
             <Date>09-13-2017</Date>
             <Version>2.8.0</Version>


### PR DESCRIPTION
Full changelog: https://slack.com/release-notes/linux

2.8.1:
- Previously in Slack app releases: we fixed the Japanese input in 2.6.3. Then we re-broke it in 2.8.0. And now it’s fixed again. Stay tuned for the next thrilling installment.
- Added bonus: An Electron update improving security. A precautionary measure, but it’s always good to be up to date.