### PR TITLE
Update Slack to 2.8.2

### DIFF
--- a/network/im/slack-desktop/pspec.xml
+++ b/network/im/slack-desktop/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Team communication for the 21st century.</Summary>
         <Description>Team communication for the 21st century.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="d1711b061c01e111dce0ee4fa5e3031d9b38381b" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.8.1-amd64.deb</Archive>
+        <Archive sha1sum="12ba41569ef64b05b10e76a085efb34857d9cc6f" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.8.2-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -37,6 +37,13 @@
     </Package>
 
     <History>
+        <Update release="13">
+            <Date>10-19-2017</Date>
+            <Version>2.8.2</Version>
+            <Comment>Update to 2.8.2</Comment>
+            <Name>Matthew Critchlow</Name>
+            <Email>matt.critchlow@gmail.com</Email>
+        </Update>
         <Update release="12">
             <Date>10-03-2017</Date>
             <Version>2.8.1</Version>


### PR DESCRIPTION
Changes:
* A small release containing nothing but another Electron update, this one better than the last.