### PR TITLE
Update TeamViewer to 12.0.85001 and fix dependencies

### DIFF
--- a/network/util/teamviewer/pspec.xml
+++ b/network/util/teamviewer/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>TeamViewer</Summary>
         <Description>Elegantly simple and extremely fast remote support, remote access, online collaboration and meetings; these are the tools for an interconnected world limited only by your imagination.</Description>
         <License>https://www.teamviewer.com/en/eula/</License>
-        <Archive sha1sum="5c227644ec3597e8533e1c5f0cb909167bb8c00b" type="binary">https://download.teamviewer.com/download/version_12x/teamviewer_12.0.76279_i386.deb</Archive>
+        <Archive sha1sum="2c6231eb86582e22c33bff6c62bc60a3b205f990" type="binary">https://download.teamviewer.com/download/version_12x/teamviewer_12.0.85001_i386.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -24,7 +24,9 @@
             <Dependency>fontconfig-32bit</Dependency>
             <Dependency>freetype2-32bit</Dependency>
             <Dependency>harfbuzz-32bit</Dependency>
+            <Dependency>libcap2-32bit</Dependency>
             <Dependency>libgcc-32bit</Dependency>
+            <Dependency>libgcrypt-32bit</Dependency>
             <Dependency>libjpeg-turbo-32bit</Dependency>
             <Dependency>libpng12-32bit</Dependency>
             <Dependency>libsm-32bit</Dependency>
@@ -37,6 +39,7 @@
             <Dependency>libxrandr-32bit</Dependency>
             <Dependency>libxrender-32bit</Dependency>
             <Dependency>libxtst-32bit</Dependency>
+            <Dependency>xz-32bit</Dependency>
             <Dependency>zlib-32bit</Dependency>
         </RuntimeDependencies>
         <Name>teamviewer</Name>
@@ -52,6 +55,13 @@
     </Package>
 
     <History>
+	<Update release="7">
+            <Date>10-29-2017</Date>
+            <Version>12.0.85001</Version>
+            <Comment>Update TeamViewer to 12.0.85001 and fix dependencies</Comment>
+            <Name>Yeray Garcia</Name>
+            <Email>yaymalaga@gmail.com</Email>
+        </Update>
         <Update release="6">
             <Date>07-01-2017</Date>
             <Version>12.0.76279</Version>


### PR DESCRIPTION
TeamViewer couldn't run because of its service couldn't start too:

Job for teamviewerd.service failed because the control process exited with error code.
See "systemctl  status teamviewerd.service" and "journalctl  -xe" for details.

Here you can see "systemctl  status teamviewerd.service" command output:

● teamviewerd.service - TeamViewer remote control daemon
   Loaded: loaded (/etc/systemd/system/teamviewerd.service; enabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since Sun 2017-10-29 12:43:35 CET; 1min 11s ago
  Process: 2289 ExecStart=/opt/teamviewer/tv_bin/teamviewerd -d (code=exited, status=127)

So I figured out using journalctl  that a few dependencies were missing, so I just added them and also updated the software.

I tested it by removing it and the new dependecies that I used, and then I installed it using my forked repository with this commit as the source and it is working properly. 

