### PR TITLE
Update Slack to 2.9.0

### DIFF
--- a/network/im/slack-desktop/pspec.xml
+++ b/network/im/slack-desktop/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Team communication for the 21st century.</Summary>
         <Description>Team communication for the 21st century.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="12ba41569ef64b05b10e76a085efb34857d9cc6f" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.8.2-amd64.deb</Archive>
+        <Archive sha1sum="22d7479c43b5c867798d1dca3c5d574149441623" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-2.9.0-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -37,6 +37,13 @@
     </Package>
 
     <History>
+        <Update release="14">
+            <Date>11-17-2017</Date>
+            <Version>2.9.0</Version>
+            <Comment>Update to 2.9.0</Comment>
+            <Name>Matthew Critchlow</Name>
+            <Email>matt.critchlow@gmail.com</Email>
+        </Update>
         <Update release="13">
             <Date>10-19-2017</Date>
             <Version>2.8.2</Version>


### PR DESCRIPTION
Slack now officially, and fully, supports Japanese. Along with the already available French, German, Spanish, and, of course, English (of the US variety). Find them under Languages & Region in your preferences menu. 