### PR TITLE
Jetbrains 2017.3

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="fedef453914b65514aae154b9be1ec3174ab3e60">https://download.jetbrains.com/cpp/CLion-2017.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="64e769c7a534129e4af074569929b7205db6be77">https://download.jetbrains.com/cpp/CLion-2017.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="8">
+          <Date>2017-12-02</Date>
+          <Version>2017.3</Version>
+          <Comment>Update to 2017.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahan94@outlook.com</Email>
+      </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="4ded49e184334ec42b671954d9f48dd925543d69" type="targz">https://download.jetbrains.com/idea/ideaIU-2017.2.5-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="7d644f3e2ed89efafc9f44dc58b3e7be3912c538" type="targz">https://download.jetbrains.com/idea/ideaIU-2017.3-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="14">
+          <Date>2017-12-02</Date>
+          <Version>2017.3</Version>
+          <Comment>Updated to 2017.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="13">
             <Date>2017-10-02</Date>
             <Version>2017.2.5</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 
 
 def install():
-    shutil.rmtree("PhpStorm-172.4155.41/jre64")
-    pisitools.insinto("/opt/phpstorm", "PhpStorm-172.4155.41/*")
+    shutil.rmtree("PhpStorm-173.3727.138/jre64")
+    pisitools.insinto("/opt/phpstorm", "PhpStorm-173.3727.138/*")
     pisitools.dosym("/opt/phpstorm/bin/phpstorm.sh", "/usr/bin/phpstorm")

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="91a2f61c14aefd55bc68a4a9194200fd4d7c9d65">https://download.jetbrains.com/webide/PhpStorm-2017.2.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="36a73229b871085fb578f430396097a5179c0c3c">https://download.jetbrains.com/webide/PhpStorm-2017.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="9">
+          <Date>2017-12-02</Date>
+          <Version>2017.3</Version>
+          <Comment>Updated to 2017.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="8">
             <Date>2017-10-01</Date>
             <Version>2017.2.4</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="4a71a0f88ec12ec63a69f319bc26d98859f88633">https://download.jetbrains.com/python/pycharm-professional-2017.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="ca9200226b1165f529efcfeb12a417998e84ad03">https://download.jetbrains.com/python/pycharm-professional-2017.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="8">
+          <Date>2017-12-02</Date>
+          <Version>2017.3</Version>
+          <Comment>Updated to 2017.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="11019f0666651f0b7cc0ca348888435e8f7d3a6c">https://download.jetbrains.com/ruby/RubyMine-2017.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="d4fbdfb1e9fd267f878f22af9ccb7fb3f19f0519">https://download.jetbrains.com/ruby/RubyMine-2017.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="9">
+          <Date>2017-12-02</Date>
+          <Version>2017.3</Version>
+          <Comment>Updated to 2017.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="8">
           <Date>2017-08-11</Date>
           <Version>2017.2.1</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 
 
 def install():
-    shutil.rmtree("WebStorm-172.3317.70/jre64")
-    pisitools.insinto("/opt/webstorm", "WebStorm-172.3317.70/*")
+    shutil.rmtree("WebStorm-173.3727.108/jre64")
+    pisitools.insinto("/opt/webstorm", "WebStorm-173.3727.108/*")
     pisitools.dosym("/opt/webstorm/bin/webstorm.sh", "/usr/bin/webstorm")

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="d2ba8c50c8bedb35698605b1af9489deee9720fc">https://download.jetbrains.com/webstorm/WebStorm-2017.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="1062084f5a9411b8914a2fea9048f949a80a91a5">https://download.jetbrains.com/webstorm/WebStorm-2017.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="8">
+          <Date>2017-12-02</Date>
+          <Version>2017.3</Version>
+          <Comment>Updated to 2017.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>


### PR DESCRIPTION
Update of all Jetbrains IDEs to version 2017.3 except for DataGrip and Rider (2017.3 not yet released).
PhpStorm and WebStorm needed their actions.py to be updated.
Every tar.gz-archive's sha256sum was checked before calculating the sha1sum for the pspec.xml.
No new warnings during build. Install and program start were successfully tested.