### PR TITLE
Update to 5.0.0

### DIFF
--- a/network/im/franz/actions.py
+++ b/network/im/franz/actions.py
@@ -9,15 +9,11 @@ IgnoreAutodep = True
 
 def setup():
     shelltools.system("pwd")
-    shelltools.system("mkdir franz")
-    shelltools.system("tar xvf Franz-linux-x64-%s.tgz -C franz" % (get.srcVERSION()))
-    shelltools.system("wget https://raw.githubusercontent.com/meetfranz/franz-pkgbuild/master/franz.sh")
-    shelltools.system("wget https://raw.githubusercontent.com/meetfranz/franz-pkgbuild/master/franz.desktop")
-    shelltools.system("wget https://raw.githubusercontent.com/meetfranz/franz-pkgbuild/master/franz.png")
-    shelltools.system("install -Dm755 franz.sh usr/bin/franz")
-    shelltools.system("install -Dm644 franz.desktop usr/share/applications/franz.desktop")
-    shelltools.system("install -Dm644 franz.png usr/share/pixmaps/franz.png")
+    shelltools.system("ar xf franz_5.0.0-beta.14_amd64.deb")
+    shelltools.system("tar xf data.tar.xz")
 
 def install():
     pisitools.insinto("/", "usr")
-    pisitools.insinto("/opt/", "franz")
+    pisitools.insinto("/", "opt")
+    pisitools.dosym("/opt/Franz/franz", "/usr/bin/franz")
+    pisitools.dosym("/usr/share/icons/hicolor/1024x1024/apps/franz.png", "/usr/share/icons/hicolor/scalable/apps/franz.png")

--- a/network/im/franz/pspec.xml
+++ b/network/im/franz/pspec.xml
@@ -11,17 +11,20 @@
         <Summary>A free messaging app that combines chat and messaging services into one application</Summary>
         <Description>Franz is a free messaging app / former Emperor of Austria and combines chat and messaging services into one application. Franz currently supports Slack, WhatsApp, WeChat, HipChat, Facebook Messenger, Telegram, Google Hangouts, GroupMe, Skype and many more.</Description>
         <License>Custom</License>
-        <Archive sha1sum="d4665d3dd5ae3c875df18475eb99dae025c10ca0" type="binary">https://github.com/meetfranz/franz-app/releases/download/4.0.4/Franz-linux-x64-4.0.4.tgz</Archive>
+        <Archive sha1sum="5ea99c85305688053539d9a8d546e546e83381f4" type="binary">https://github.com/meetfranz/franz/releases/download/v5.0.0-beta.14/franz_5.0.0-beta.14_amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
-            <Dependency>wget</Dependency>
         </BuildDependencies>
     </Source>
 
     <Package>
         <Name>franz</Name>
         <Files>
-            <Path fileType="*">/</Path>
+          <Path fileType="binary">/usr/bin/franz</Path>
+          <Path fileType="data">/opt/Franz</Path>
+          <Path fileType="doc">/usr/share/doc</Path>
+          <Path fileType="data">/usr/share/applications</Path>
+          <Path fileType="icon">/usr/share/icons</Path>
         </Files>
         <RuntimeDependencies>
             <Dependency>gconf</Dependency>
@@ -30,6 +33,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="8">
+          <Date>11-12-2017</Date>
+          <Version>5.0.0</Version>
+          <Comment>Update to 5.0.0</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="7">
             <Date>14-02-2017</Date>
             <Version>4.0.4</Version>


### PR DESCRIPTION
Fixes issues #251 and #254.
Updates Franz to version 5.0.0.

Franz can no longer be build from the tarball, so I modified the files to use the debian archive instead.

Tested:
Build, Installation, Execution.