### PR TITLE
Update Slack to 3.0.2

### DIFF
--- a/network/im/slack-desktop/pspec.xml
+++ b/network/im/slack-desktop/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Team communication for the 21st century.</Summary>
         <Description>Team communication for the 21st century.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="0c8d5e9d3b2f2b1f35653455dd201061350ca4f5" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-3.0.0-amd64.deb</Archive>
+        <Archive sha1sum="2cd28deb26c3b856fb50b7086dbd3d9cab2f1c91" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-3.0.2-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -37,6 +37,13 @@
     </Package>
 
     <History>
+        <Update release="16">
+            <Date>12-27-2017</Date>
+            <Version>3.0.2</Version>
+            <Comment>Update to 3.0.2</Comment>
+            <Name>Matthew Critchlow</Name>
+            <Email>matt.critchlow@gmail.com</Email>
+        </Update>
         <Update release="15">
             <Date>12-08-2017</Date>
             <Version>3.0.0</Version>


### PR DESCRIPTION
Bug Fixes:
- A rare case that could cause Slack to crash when showing a proxy configuration dialog at startup has now, thankfully, been fixed.
