### PR TITLE
Update flash player NPAPI & PPAPI to 28.0.0.137

### DIFF
--- a/multimedia/video/flash-player-npapi/pspec.xml
+++ b/multimedia/video/flash-player-npapi/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>Adobe Flash Player (NPAPI)</Summary>
         <Description>Adobe Flash Player (NPAPI).</Description>
         <License>EULA</License>
-        <Archive sha1sum="7113e92f74cf0af528844b00a046e71275b91912" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/28.0.0.126/flash_player_npapi_linux.x86_64.tar.gz</Archive>
+        <Archive sha1sum="632c479f83bfd2a4d814b565c0b1badab81a36f0" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/28.0.0.137/flash_player_npapi_linux.x86_64.tar.gz</Archive>
     </Source>
     <Package>
         <Name>flash-player-npapi</Name>
@@ -29,6 +29,14 @@
     </Package>
 
     <History>
+        <Update release="17">
+            <Date>01-10-2018</Date>
+            <Version>28.0.0.137</Version>
+            <Comment>Update to 28.0.0.137</Comment>
+            <Name>Pierre-Yves</Name>
+            <Email>pyu@riseup.net</Email>
+        </Update>
+
         <Update release="16">
             <Date>12-15-2017</Date>
             <Version>28.0.0.126</Version>

--- a/multimedia/video/flash-player-ppapi/pspec.xml
+++ b/multimedia/video/flash-player-ppapi/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>Adobe Flash Player (PPAPI)</Summary>
         <Description>Adobe Flash Player (PPAPI).</Description>
         <License>EULA</License>
-        <Archive sha1sum="1cc5999da0c7d5d92619a5768d08e30aef570c5e" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/28.0.0.126/flash_player_ppapi_linux.x86_64.tar.gz</Archive>
+        <Archive sha1sum="0802eea9da81e0809cc18158eb25d75c5152eb72" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/28.0.0.137/flash_player_ppapi_linux.x86_64.tar.gz</Archive>
     </Source>
     <Package>
         <Name>flash-player-ppapi</Name>
@@ -22,6 +22,14 @@
     </Package>
 
     <History>
+        <Update release="17">
+            <Date>12-15-2017</Date>
+            <Version>28.0.0.137</Version>
+            <Comment>Update to 28.0.0.137</Comment>
+            <Name>Pierre-Yves</Name>
+            <Email>pyu@riseup.net</Email>
+        </Update>
+
         <Update release="16">
             <Date>12-15-2017</Date>
             <Version>28.0.0.126</Version>


### PR DESCRIPTION
Resolves
```
Program terminated.
Could not fetch destination file "https://www.solus-project.com/source/flash_player_ppapi_linux.x86_64.tar.gz": [Errno 14] HTTPS Error 404 - Not Found
```

Signed-off-by: Pierre-Yves <pyu@riseup.net>