### PR TITLE
Update Slack to 3.0.5

### DIFF
--- a/network/im/slack-desktop/pspec.xml
+++ b/network/im/slack-desktop/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Team communication for the 21st century.</Summary>
         <Description>Team communication for the 21st century.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="2cd28deb26c3b856fb50b7086dbd3d9cab2f1c91" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-3.0.2-amd64.deb</Archive>
+        <Archive sha1sum="0ca8ed9b7879d112c58b95e3f73bf8bfd3f9550d" type="binary">https://downloads.slack-edge.com/linux_releases/slack-desktop-3.0.5-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -37,6 +37,13 @@
     </Package>
 
     <History>
+        <Update release="17">
+            <Date>01-17-2017</Date>
+            <Version>3.0.5</Version>
+            <Comment>Update to 3.0.5</Comment>
+            <Name>Matthew Critchlow</Name>
+            <Email>matt.critchlow@gmail.com</Email>
+        </Update>
         <Update release="16">
             <Date>12-27-2017</Date>
             <Version>3.0.2</Version>


### PR DESCRIPTION
From [Release Notes](https://slack.com/release-notes/linux):
- An important security update. Security updates are always important. This is one of those.