### PR TITLE
Update Ocenaudio version to 3.3.10 (current pspec.xml broken)

### DIFF
--- a/multimedia/music/ocenaudio/pspec.xml
+++ b/multimedia/music/ocenaudio/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Ocenaudio is a fast, cross-platform audio editor.</Summary>
         <Description>Ocenaudio is a fast, cross-platform audio editor.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="b7a9a2bae6a672dbc993bde863e5ed4f03933afe" type="binary">https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian64.deb</Archive>
+        <Archive sha1sum="fd8dfd94fa041098540636b8f5c352c49669240f" type="binary">https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>

--- a/multimedia/music/ocenaudio/pspec.xml
+++ b/multimedia/music/ocenaudio/pspec.xml
@@ -32,6 +32,14 @@
     </Package>
 
     <History>
+        <Update release="12">
+            <Date>02-07-2018</Date>
+            <Version>3.3.10</Version>
+            <Comment>Update to 3.3.10</Comment>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
+        </Update>
+        
         <Update release="11">
             <Date>06-29-2017</Date>
             <Version>3.2.11</Version>


### PR DESCRIPTION
The old pspec.xml doesn't work since the link now downloads a different binary. I noticed this when someone in the #Solus chat asked for help with installing Ocenaudio. 

Update the hash to enable building the package again, which means upgrading to version 3.3.10.

I hope this is the right way to do this, otherwise comments would be much appreciated.