### PR TITLE
Update Jetbrains IDEs CW8

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="fec8d9704562894d4a5caa2d155746109766cf3e">https://download.jetbrains.com/datagrip/datagrip-2017.3.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="295595669610b6008aacea38f8daf8f2c0ef00e7">https://download.jetbrains.com/datagrip/datagrip-2017.3.6.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="13">
+          <Date>2018-02-23</Date>
+          <Version>2017.3.6</Version>
+          <Comment>Updated to 2017.3.6</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="12">
           <Date>2018-02-16</Date>
           <Version>2017.3.5</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 8.

Update DataGrip to version 2017.3.6
Everything else still up to date.
Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com