### PR TITLE
Update Chrome Stable to 64.0.3282.186

### DIFF
--- a/network/web/browser/google-chrome-stable/pspec.xml
+++ b/network/web/browser/google-chrome-stable/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>The web browser from Google</Summary>
         <Description> Google Chrome is a browser that combines a minimal design with sophisticated technology to make the web faster, safer, and easier.</Description>
         <License>EULA</License>
-        <Archive sha1sum="611ed5cb90a206b5245dd7645e4dcebf311f9a41" type="binary">http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_64.0.3282.167-1_amd64.deb</Archive>
+        <Archive sha1sum="502db3a41f6ca920ef86b9ae3a62d6a358a9ccc4" type="binary">http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_64.0.3282.186-1_amd64.deb</Archive>
 
         <BuildDependencies>
             <Dependency>libxscrnsaver</Dependency>
@@ -41,6 +41,14 @@
     </Package>
 
     <History>
+        <Update release="113">
+            <Date>02-22-2018</Date>
+            <Version>64.0.3282.186</Version>
+            <Comment>Update to 64.0.3282.186</Comment>
+            <Name>Henrik Steen</Name>
+            <Email>henrik.steen@strossle.com</Email>
+        </Update>
+
         <Update release="112">
             <Date>02-13-2018</Date>
             <Version>64.0.3282.167</Version>


### PR DESCRIPTION
Ref:
https://chromereleases.googleblog.com/2018/02/stable-channel-update-for-desktop_22.html