### PR TITLE
Update Jetbrains IDEs CW9

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="295595669610b6008aacea38f8daf8f2c0ef00e7">https://download.jetbrains.com/datagrip/datagrip-2017.3.6.tar.gz</Archive>
+        <Archive type="targz" sha1sum="9f3646644fb16a84a683576f00abcd4e3953f444">https://download.jetbrains.com/datagrip/datagrip-2017.3.7.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="14">
+          <Date>2018-03-02</Date>
+          <Version>2017.3.7</Version>
+          <Comment>Updated to 2017.3.7</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="13">
           <Date>2018-02-23</Date>
           <Version>2017.3.6</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="da63efb5c0144d0b7520b7069cdbbd5e1005f5d7">https://download.jetbrains.com/ruby/RubyMine-2017.3.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="767fdf08e798cd2b62da15b157334a9a52f57fd2">https://download.jetbrains.com/ruby/RubyMine-2017.3.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+          <Update release="11">
+          <Date>2018-03-02</Date>
+          <Version>2017.3.3</Version>
+          <Comment>Updated to 2017.3.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="10">
           <Date>2018-02-02</Date>
           <Version>2017.3.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 9.

Updating
- DataGrip to version 2017.3.7
- RubyMine to version 2017.3.3

Everything else still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com