### PR TITLE
Update Jetbrains IDEs CW10

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="3830e93bb5e91dc9ea91c56007baa0c14a696c45">https://download.jetbrains.com/cpp/CLion-2017.3.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="926fbbd7e5c311f5baf9e98679dd1fee9d7471e9">https://download.jetbrains.com/cpp/CLion-2017.3.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,19 +30,26 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="10">
+          <Date>2018-03-09</Date>
+          <Version>2017.3.4</Version>
+          <Comment>Update to 2017.3.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="9">
           <Date>2018-02-02</Date>
           <Version>2017.3.3</Version>
           <Comment>Update to 2017.3.3</Comment>
           <Name>ahahn94</Name>
-          <Email>ahan94@outlook.com</Email>
+          <Email>ahahn94@outlook.com</Email>
       </Update>
       <Update release="8">
           <Date>2017-12-02</Date>
           <Version>2017.3</Version>
           <Comment>Update to 2017.3</Comment>
           <Name>ahahn94</Name>
-          <Email>ahan94@outlook.com</Email>
+          <Email>ahahn94@outlook.com</Email>
       </Update>
         <Update release="7">
             <Date>2017-07-27</Date>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="34a0e1d446247a14170ede33e28bacf43f79c3a4">https://download.jetbrains.com/python/pycharm-community-2017.3.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="c9ff1f45be5b055b164d050984aba8796ba69cf8">https://download.jetbrains.com/python/pycharm-community-2017.3.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="8">
+          <Date>2018-03-09</Date>
+          <Version>2017.3.4</Version>
+          <Comment>Updated to 2017.3.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="7">
           <Date>2018-02-02</Date>
           <Version>2017.3.3</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="2ce125a5819fbf882ac1554e8acf304819eddc9c">https://download.jetbrains.com/python/pycharm-professional-2017.3.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="d178b5b34b7ac9cfabbb5d8dee44701f0a8c5512">https://download.jetbrains.com/python/pycharm-professional-2017.3.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="11">
+          <Date>2018-03-09</Date>
+          <Version>2017.3.4</Version>
+          <Comment>Updated to 2017.3.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="10">
           <Date>2018-02-02</Date>
           <Version>2017.3.3</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 
 
 def install():
-    shutil.rmtree("WebStorm-173.4548.30/jre64")
-    pisitools.insinto("/opt/webstorm", "WebStorm-173.4548.30/*")
+    shutil.rmtree("WebStorm-173.4674.32/jre64")
+    pisitools.insinto("/opt/webstorm", "WebStorm-173.4674.32/*")
     pisitools.dosym("/opt/webstorm/bin/webstorm.sh", "/usr/bin/webstorm")

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="dde1eb1c95072f1ecc944166180ddb05a62fa62f">https://download.jetbrains.com/webstorm/WebStorm-2017.3.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="f0526c39b2da6c21066450ed96322dd817af05fc">https://download.jetbrains.com/webstorm/WebStorm-2017.3.5.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="11">
+          <Date>2018-03-09</Date>
+          <Version>2017.3.5</Version>
+          <Comment>Updated to 2017.3.5</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="10">
           <Date>2018-02-02</Date>
           <Version>2017.3.4</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 10.

Updating
- Clion to version 2017.3.4
- PyCharm to version 2017.3.4
- PyCharm-CE to version 2017.3.4
- WebStorm to version 2017.3.5
Everything else still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com