### PR TITLE
update npapi and ppapi flash to 29.0.0.113

### DIFF
--- a/multimedia/video/flash-player-npapi/pspec.xml
+++ b/multimedia/video/flash-player-npapi/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>Adobe Flash Player (NPAPI)</Summary>
         <Description>Adobe Flash Player (NPAPI).</Description>
         <License>EULA</License>
-        <Archive sha1sum="92521f5d2d04600f32fdd1595fb61cd23e384d98" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/28.0.0.161/flash_player_npapi_linux.x86_64.tar.gz</Archive>
+        <Archive sha1sum="b7be0c43150b373b37557ec752e240bc13188fea" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/29.0.0.113/flash_player_npapi_linux.x86_64.tar.gz</Archive>
     </Source>
     <Package>
         <Name>flash-player-npapi</Name>
@@ -29,6 +29,14 @@
     </Package>
 
     <History>
+        <Update release="19">
+            <Date>03-17-2018</Date>
+            <Version>29.0.0.113</Version>
+            <Comment>Update to 29.0.0.113</Comment>
+            <Name>ThanosApostolou</Name>
+            <Email>thanosapostolou@outlook.com</Email>
+        </Update>
+
         <Update release="18">
             <Date>02-09-2018</Date>
             <Version>28.0.0.161</Version>

--- a/multimedia/video/flash-player-ppapi/pspec.xml
+++ b/multimedia/video/flash-player-ppapi/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>Adobe Flash Player (PPAPI)</Summary>
         <Description>Adobe Flash Player (PPAPI).</Description>
         <License>EULA</License>
-        <Archive sha1sum="6ecdf3832797ceefb2919d45898d19a4a0138a2d" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/28.0.0.161/flash_player_ppapi_linux.x86_64.tar.gz</Archive>
+        <Archive sha1sum="26d5564e99939114b5470498da74413df4819b9f" type="targz">https://fpdownload.adobe.com/get/flashplayer/pdc/29.0.0.113/flash_player_ppapi_linux.x86_64.tar.gz</Archive>
     </Source>
     <Package>
         <Name>flash-player-ppapi</Name>
@@ -22,6 +22,14 @@
     </Package>
 
     <History>
+        <Update release="19">
+            <Date>03-17-2018</Date>
+            <Version>29.0.0.113</Version>
+            <Comment>Update to 29.0.0.113</Comment>
+            <Name>ThanosApostolou</Name>
+            <Email>thanosapostolou@outlook.com</Email>
+        </Update>
+
         <Update release="18">
             <Date>02-09-2018</Date>
             <Version>28.0.0.161</Version>


### PR DESCRIPTION
Flash players are not able to be installed anymore from solus-sc 3rd party section. So, I updated them  to version 29.0.0.113. Both built successfully. Tested only npapi in real webpages with firefox.