### PR TITLE
Update JetBrains IDEs CW13

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="926fbbd7e5c311f5baf9e98679dd1fee9d7471e9">https://download.jetbrains.com/cpp/CLion-2017.3.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="5f8a3ff649255ef1a02843cfb2bda20030f03672">https://download.jetbrains.com/cpp/CLion-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="11">
+          <Date>2018-03-30</Date>
+          <Version>2018.1</Version>
+          <Comment>Update to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="10">
           <Date>2018-03-09</Date>
           <Version>2017.3.4</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="c5d491be58eb8506473c2cba43972a50dc98afe1" type="targz">https://download.jetbrains.com/idea/ideaIU-2017.3.5-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="12ca75cc4a9da235bd68be1f96086c3f41223209" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="18">
+          <Date>2018-03-30</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="17">
           <Date>2018-03-16</Date>
           <Version>2017.3.5</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 
 
 def install():
-    shutil.rmtree("PhpStorm-173.4674.46/jre64")
-    pisitools.insinto("/opt/phpstorm", "PhpStorm-173.4674.46/*")
+    shutil.rmtree("PhpStorm-181.4203.565/jre64")
+    pisitools.insinto("/opt/phpstorm", "PhpStorm-181.4203.565/*")
     pisitools.dosym("/opt/phpstorm/bin/phpstorm.sh", "/usr/bin/phpstorm")

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="cf55dbcf7982e67f55a520d5c9e47f4221236fce">https://download.jetbrains.com/webide/PhpStorm-2017.3.6.tar.gz</Archive>
+        <Archive type="targz" sha1sum="5843961073fa0cb8d0e23504a1b6289e00533450">https://download.jetbrains.com/webide/PhpStorm-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="13">
+          <Date>2018-03-30</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="12">
           <Date>2018-03-16</Date>
           <Version>2017.3.6</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="c9ff1f45be5b055b164d050984aba8796ba69cf8">https://download.jetbrains.com/python/pycharm-community-2017.3.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="d14be863d4221f3b11db2666125f873e375afb9f">https://download.jetbrains.com/python/pycharm-community-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="9">
+          <Date>2018-03-30</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="8">
           <Date>2018-03-09</Date>
           <Version>2017.3.4</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="d178b5b34b7ac9cfabbb5d8dee44701f0a8c5512">https://download.jetbrains.com/python/pycharm-professional-2017.3.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="95293574b5167d253216a6c4f26e3831fb19f919">https://download.jetbrains.com/python/pycharm-professional-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="12">
+          <Date>2018-03-30</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="11">
           <Date>2018-03-09</Date>
           <Version>2017.3.4</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -7,6 +7,6 @@ WorkDir = "."
 
 
 def install():
-    shutil.rmtree("WebStorm-173.4674.32/jre64")
-    pisitools.insinto("/opt/webstorm", "WebStorm-173.4674.32/*")
+    shutil.rmtree("WebStorm-181.4203.535/jre64")
+    pisitools.insinto("/opt/webstorm", "WebStorm-181.4203.535/*")
     pisitools.dosym("/opt/webstorm/bin/webstorm.sh", "/usr/bin/webstorm")

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="f0526c39b2da6c21066450ed96322dd817af05fc">https://download.jetbrains.com/webstorm/WebStorm-2017.3.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="cc2cf0c203ceb776369a78b8d0dc4e89a9541019">https://download.jetbrains.com/webstorm/WebStorm-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="11">
+          <Date>2018-03-30</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="11">
           <Date>2018-03-09</Date>
           <Version>2017.3.5</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 13.
First major update of this year.

Updating
- CLion 2018.1
- Idea 2018.1
- PhpStorm 2018.1
- PyCharm 2018.1
- PyCharm 2018.1
- WebStorm 2018.1

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com