### PR TITLE
Update JetBrains CW14

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="9f3646644fb16a84a683576f00abcd4e3953f444">https://download.jetbrains.com/datagrip/datagrip-2017.3.7.tar.gz</Archive>
+        <Archive type="targz" sha1sum="70b5e6e1b42baf7d41c3d17b0ac71a9cf1d744d1">https://download.jetbrains.com/datagrip/datagrip-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="15">
+          <Date>2018-04-06</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="14">
           <Date>2018-03-02</Date>
           <Version>2017.3.7</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="767fdf08e798cd2b62da15b157334a9a52f57fd2">https://download.jetbrains.com/ruby/RubyMine-2017.3.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="5b0aa967ac22ecf1127cd36f650dbb40e139397a">https://download.jetbrains.com/ruby/RubyMine-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,14 +30,21 @@
         </RuntimeDependencies>
     </Package>
     <History>
-          <Update release="11">
+        <Update release="12">
+          <Date>2018-04-06</Date>
+          <Version>2018.1</Version>
+          <Comment>Updated to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
           <Date>2018-03-02</Date>
           <Version>2017.3.3</Version>
           <Comment>Updated to 2017.3.3</Comment>
           <Name>ahahn94</Name>
           <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="10">
+        </Update>
+        <Update release="10">
           <Date>2018-02-02</Date>
           <Version>2017.3.2</Version>
           <Comment>Updated to 2017.3.2</Comment>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 14.

Updating
- DataGrip 2018.1
- RubyMine 2018.1
Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com