### PR TITLE
Update Skype to version 8.20.76.1 (see notes)

### DIFF
--- a/network/im/skype/pspec.xml
+++ b/network/im/skype/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Skype keeps the world talking, for free.</Summary>
         <Description>Skype keeps you together. Call, message and share with others.</Description>
         <License>Copyright (c) 2017 Skype and/or Microsoft</License>
-        <Archive sha1sum="317752b64dab3a0553a5b342323b4bb04deda0c9" type="binary">https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.19.76.8_amd64.deb</Archive>
+        <Archive sha1sum="0a9944a98fd372b38a1b79ce588b7729c6b39844" type="binary">https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.20.76.1_amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -35,6 +35,14 @@
     </Package>
     
     <History>
+        <Update release="47">
+            <Date>04-12-2018</Date>
+            <Version>8.20.76.1</Version>
+            <Comment>Update to 8.20.76.1</Comment>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
+        </Update>
+        
         <Update release="46">
             <Date>04-10-2018</Date>
             <Version>8.19.76.8</Version>


### PR DESCRIPTION
Second update in two day. But this time there seems to be a visual glitch with the tray icon, at least on Budgie: [https://i.imgur.com/cQ1Lg3b.png](https://i.imgur.com/cQ1Lg3b.png)

Maybe it would be better to wait for the next minor version (but then users might complain about the update notification). I guess the tray icon is worse. Just creating this pull request so you have the choice.