### PR TITLE
Update JetBrains CW15

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="5f8a3ff649255ef1a02843cfb2bda20030f03672">https://download.jetbrains.com/cpp/CLion-2018.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="ef7a41b3fa40a45a74487fda49ca814ed596031c">https://download.jetbrains.com/cpp/CLion-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="12">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Update to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="11">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>

--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="9f3646644fb16a84a683576f00abcd4e3953f444">https://download.jetbrains.com/datagrip/datagrip-2017.3.7.tar.gz</Archive>
+        <Archive type="targz" sha1sum="40bcaaebfafec0d9c7d41f2eb6c16842d762859b">https://download.jetbrains.com/datagrip/datagrip-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="15">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="14">
           <Date>2018-03-02</Date>
           <Version>2017.3.7</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="12ca75cc4a9da235bd68be1f96086c3f41223209" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="4bf1e19f7d9bf1527455f801ce1f168ac4c2cf23" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.1-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="19">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="18">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,9 +4,9 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-
+Build = "181.4445.72"
 
 def install():
-    shutil.rmtree("PhpStorm-181.4203.565/jre64")
-    pisitools.insinto("/opt/phpstorm", "PhpStorm-181.4203.565/*")
+    shutil.rmtree("PhpStorm-%s/jre64" % Build)
+    pisitools.insinto("/opt/phpstorm", "PhpStorm-%s/*" % Build)
     pisitools.dosym("/opt/phpstorm/bin/phpstorm.sh", "/usr/bin/phpstorm")

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="5843961073fa0cb8d0e23504a1b6289e00533450">https://download.jetbrains.com/webide/PhpStorm-2018.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="38a5074117d86c33ae69419687528d2b6c02810f">https://download.jetbrains.com/webide/PhpStorm-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="14">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="13">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="d14be863d4221f3b11db2666125f873e375afb9f">https://download.jetbrains.com/python/pycharm-community-2018.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="6ffdb1a7d57bd923b4fec1c86732d1f856cd4b2f">https://download.jetbrains.com/python/pycharm-community-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="10">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="9">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="95293574b5167d253216a6c4f26e3831fb19f919">https://download.jetbrains.com/python/pycharm-professional-2018.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="1f209d12459c1786266a4b3bb73116ae61bfc3de">https://download.jetbrains.com/python/pycharm-professional-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="13">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="12">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="767fdf08e798cd2b62da15b157334a9a52f57fd2">https://download.jetbrains.com/ruby/RubyMine-2017.3.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="ca5f48f7aa2ab6507ec8b81b18d6312b7c941c1e">https://download.jetbrains.com/ruby/RubyMine-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,7 +30,14 @@
         </RuntimeDependencies>
     </Package>
     <History>
-          <Update release="11">
+        <Update release="12">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
+      <Update release="11">
           <Date>2018-03-02</Date>
           <Version>2017.3.3</Version>
           <Comment>Updated to 2017.3.3</Comment>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,9 +4,9 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-
+Build = "181.4445.68"
 
 def install():
-    shutil.rmtree("WebStorm-181.4203.535/jre64")
-    pisitools.insinto("/opt/webstorm", "WebStorm-181.4203.535/*")
+    shutil.rmtree("WebStorm-%s/jre64" % Build)
+    pisitools.insinto("/opt/webstorm", "WebStorm-%s/*" % Build)
     pisitools.dosym("/opt/webstorm/bin/webstorm.sh", "/usr/bin/webstorm")

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="cc2cf0c203ceb776369a78b8d0dc4e89a9541019">https://download.jetbrains.com/webstorm/WebStorm-2018.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="48c2811559440d8a89323b16a2e91dc260ceed96">https://download.jetbrains.com/webstorm/WebStorm-2018.1.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="12">
+          <Date>2018-04-13</Date>
+          <Version>2018.1.1</Version>
+          <Comment>Updated to 2018.1.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="11">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 15.

Updating:
- CLion to version 2018.1.1
- DataGrip to version 2018.1.1
- Idea to version 2018.1.1
- PhpStorm to version 2018.1.1
- PyCharm to version 2018.1.1
- PyCharm-CE to version 2018.1.1
- RubyMine to version 2018.1.1
- WebStorm to version 2018.1.1

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com