### PR TITLE
Update JetBrains CW16

### DIFF
--- a/programming/rider/pspec.xml
+++ b/programming/rider/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Summary>
         <Description xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Description>
-        <Archive type="targz" sha1sum="0e99d39c0f0b1383e46729b01599e91be72a94b0">https://download.jetbrains.com/resharper/JetBrains.Rider-2017.3.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="ce5b88b1f67f455baff925aa9d4e60f12d658961">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rider</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="3">
+          <Date>2018-04-20</Date>
+          <Version>2018.1</Version>
+          <Comment>Update to 2018.1</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="2">
           <Date>2018-02-07</Date>
           <Version>2017.3.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 16.

Updating:
- Rider to version 2018.1

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 <ahahn94@outlook.com>