### PR TITLE
Update JetBrains CW17

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="ef7a41b3fa40a45a74487fda49ca814ed596031c">https://download.jetbrains.com/cpp/CLion-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="aa49d2a9e2f6a927e06a4c092aee02ac43efbb0d">https://download.jetbrains.com/cpp/CLion-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="13">
+          <Date>2018-04-27</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Update to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="12">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="4bf1e19f7d9bf1527455f801ce1f168ac4c2cf23" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.1-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="f283978b4b19165c9299f0951f1e820392b002ff" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.2-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="20">
+          <Date>2018-04-27</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="19">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.4445.72"
+Build = "181.4668.78"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="38a5074117d86c33ae69419687528d2b6c02810f">https://download.jetbrains.com/webide/PhpStorm-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="90f13bc6c87c6c50d2be89706935d4c74420d7de">https://download.jetbrains.com/webide/PhpStorm-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="15">
+          <Date>2018-04-27</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="14">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="6ffdb1a7d57bd923b4fec1c86732d1f856cd4b2f">https://download.jetbrains.com/python/pycharm-community-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="45a0a24649104209d94410d96f4058da6e242dd5">https://download.jetbrains.com/python/pycharm-community-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="11">
+          <Date>2018-04-27</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="10">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="1f209d12459c1786266a4b3bb73116ae61bfc3de">https://download.jetbrains.com/python/pycharm-professional-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="e5b78d69b16d663a63ee13184fcd1df3862893e6">https://download.jetbrains.com/python/pycharm-professional-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,20 +30,27 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="14">
+          <Date>2018-04-27</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+    </Update>
     <Update release="13">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>
           <Comment>Updated to 2018.1.1</Comment>
           <Name>ahahn94</Name>
           <Email>ahahn94@outlook.com</Email>
-      </Update>
+    </Update>
     <Update release="12">
           <Date>2018-03-30</Date>
           <Version>2018.1</Version>
           <Comment>Updated to 2018.1</Comment>
           <Name>ahahn94</Name>
           <Email>ahahn94@outlook.com</Email>
-      </Update>
+    </Update>
     <Update release="11">
           <Date>2018-03-09</Date>
           <Version>2017.3.4</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.4445.68"
+Build = "181.4668.60"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="48c2811559440d8a89323b16a2e91dc260ceed96">https://download.jetbrains.com/webstorm/WebStorm-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="c6404c583a4ecaba7ca7cdf33917ec5cd6c3f8c5">https://download.jetbrains.com/webstorm/WebStorm-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="13">
+          <Date>2018-04-27</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="12">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 17.

Updating:

- CLion to 2018.1.2
- Idea to 2018.1.2
- PhpStorm to 2018.1.2
- PyCharm to 2018.1.2
- PyCharm-CE to 2018.1.2
- WebStorm to 2018.1.2
Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com