### PR TITLE
Update JetBrains CW18

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="40bcaaebfafec0d9c7d41f2eb6c16842d762859b">https://download.jetbrains.com/datagrip/datagrip-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="1865eb4086a6c33b6f9d663ec18c7ac62b35e988">https://download.jetbrains.com/datagrip/datagrip-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="16">
+          <Date>2018-05-04</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="15">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 18.

Updating:
- DataGrip to version 2018.1.2

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com