### PR TITLE
Update Sublime Text 3 to the latest stable build 3170

### DIFF
--- a/programming/sublime-text-3/pspec.xml
+++ b/programming/sublime-text-3/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>Sublime Text is a sophisticated text editor for code, markup and prose.</Summary>
         <Description> Sublime Text is a sophisticated text editor for code, markup and prose.</Description>
         <License>EULA</License>
-        <Archive sha1sum="a8ad4c8a415f5de28b6eaef86b7ebc59c480f032" type="binary">https://download.sublimetext.com/sublime-text_build-3143_amd64.deb</Archive>
+        <Archive sha1sum="aed3e27c1033d7ee9ec7e55d8432f410677ef183" type="binary">https://download.sublimetext.com/sublime-text_build-3170_amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>libxscrnsaver</Dependency>
             <Dependency>gconf</Dependency>
@@ -31,6 +31,13 @@
     </Package>
 
     <History>
+        <Update release="5">
+            <Date>07-05-18</Date>
+            <Version>3170</Version>
+            <Comment>Update to 3170</Comment>
+            <Name>James Lee</Name>
+            <Email>jamesl33info@gmail.com</Email>
+        </Update>
         <Update release="4">
             <Date>09-13-2017</Date>
             <Version>3143</Version>
@@ -38,7 +45,6 @@
             <Name>Stefan Ric</Name>
             <Email>stfric369@gmail.com</Email>
         </Update>
-
         <Update release="3">
             <Date>25-09-2016</Date>
             <Version>3126</Version>


### PR DESCRIPTION
Update Sublime Text 3 to version [3170](https://www.sublimetext.com/blog/articles/sublime-text-3-point-1).

Updating:
* Sublime Text to version 3170

Tested:
Build, install and execution.

