### PR TITLE
Update JetBrains CW19

### DIFF
--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="f283978b4b19165c9299f0951f1e820392b002ff" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.2-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="200f8578fb2044465b7a21bc03a6b8058e048dc5" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.3-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="21">
+          <Date>2018-05-11</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Updated to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="20">
           <Date>2018-04-27</Date>
           <Version>2018.1.2</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.4668.78"
+Build = "181.4892.97"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="90f13bc6c87c6c50d2be89706935d4c74420d7de">https://download.jetbrains.com/webide/PhpStorm-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="e06eb63a0833466d4aec318bdf9dc1e7981a845f">https://download.jetbrains.com/webide/PhpStorm-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="16">
+          <Date>2018-05-11</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Updated to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="15">
           <Date>2018-04-27</Date>
           <Version>2018.1.2</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="ca5f48f7aa2ab6507ec8b81b18d6312b7c941c1e">https://download.jetbrains.com/ruby/RubyMine-2018.1.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="ed1dfe1b035cd47f16a6843c22481c1d10e1f805">https://download.jetbrains.com/ruby/RubyMine-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="13">
+          <Date>2018-05-11</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Updated to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="12">
           <Date>2018-04-13</Date>
           <Version>2018.1.1</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.4668.60"
+Build = "181.4892.44"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="c6404c583a4ecaba7ca7cdf33917ec5cd6c3f8c5">https://download.jetbrains.com/webstorm/WebStorm-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="531881bc5760dfaf05e4d8888f89a4a9c3e4f1a9">https://download.jetbrains.com/webstorm/WebStorm-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="14">
+          <Date>2018-05-11</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Updated to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="13">
           <Date>2018-04-27</Date>
           <Version>2018.1.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 18.

Updating:
- Idea to version 2018.1.3
- PhpStorm to version 2018.1.3
- RubyMine to version 2018.1.2
- WebStorm to version 2018.1.3

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com