### PR TITLE
GitKraken: Update to version 3.6.1

### DIFF
--- a/programming/gitkraken/pspec.xml
+++ b/programming/gitkraken/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>The downright luxurious Git client, for Windows, Mac and Linux</Summary>
         <Description>The downright luxurious Git client, for Windows, Mac and Linux</Description>
         <License>EULA</License>
-        <Archive sha1sum="bb957bd09bca1bcc78c8459fd0e6f2f67fb93bf0" type="binary">https://release.gitkraken.com/linux/gitkraken-amd64.deb</Archive>
+        <Archive sha1sum="16f9dba85fa51c7430198c9c093d7220ccfcb987" type="binary">https://release.gitkraken.com/linux/gitkraken-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>libxscrnsaver</Dependency>
             <Dependency>gconf</Dependency>
@@ -35,6 +35,14 @@
     </Package>
 
     <History>
+        <Update release="48">
+            <Date>05-17-2018</Date>
+            <Version>3.6.1</Version>
+            <Comment>Update to 3.6.1</Comment>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
+        </Update>
+        
         <Update release="47">
             <Date>05-04-2018</Date>
             <Version>3.6.0</Version>


### PR DESCRIPTION
Current version of pspec.xml doesn't work anymore since the .deb behind the link got updated