### PR TITLE
Update JetBrains CW20

### DIFF
--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="45a0a24649104209d94410d96f4058da6e242dd5">https://download.jetbrains.com/python/pycharm-community-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="3a36c8c268495a9dab832290bf407b06fa3c41d8">https://download.jetbrains.com/python/pycharm-community-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="12">
+          <Date>2018-05-18</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Updated to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="11">
           <Date>2018-04-27</Date>
           <Version>2018.1.2</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="e5b78d69b16d663a63ee13184fcd1df3862893e6">https://download.jetbrains.com/python/pycharm-professional-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="3f97fd7424512347e00656eafadd5d5568d07a90">https://download.jetbrains.com/python/pycharm-professional-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="15">
+          <Date>2018-05-18</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Updated to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+    </Update>
     <Update release="14">
           <Date>2018-04-27</Date>
           <Version>2018.1.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 20.

Updating:
- PyCharm to version 2018.1.3
- PyCharm-CE to version 2018.1.3

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com