### PR TITLE
Update JetBrains CW21

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="aa49d2a9e2f6a927e06a4c092aee02ac43efbb0d">https://download.jetbrains.com/cpp/CLion-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="fe75a3d81c6db3ef4a5fad2bd424d33b6688c621">https://download.jetbrains.com/cpp/CLion-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="14">
+          <Date>2018-05-25</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Update to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="13">
           <Date>2018-04-27</Date>
           <Version>2018.1.2</Version>

--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="1865eb4086a6c33b6f9d663ec18c7ac62b35e988">https://download.jetbrains.com/datagrip/datagrip-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="7e5ddbe1ea3b74052372e300c7b8b0769bdce710">https://download.jetbrains.com/datagrip/datagrip-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="17">
+          <Date>2018-05-25</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Updated to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="16">
           <Date>2018-05-04</Date>
           <Version>2018.1.2</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="200f8578fb2044465b7a21bc03a6b8058e048dc5" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.3-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="f0ce575a2d6cad22a0e66621b656e19fd11113ce" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.4-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="22">
+          <Date>2018-05-25</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Updated to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="21">
           <Date>2018-05-11</Date>
           <Version>2018.1.3</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.4892.97"
+Build = "181.5087.24"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="e06eb63a0833466d4aec318bdf9dc1e7981a845f">https://download.jetbrains.com/webide/PhpStorm-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="7a1a5656d2d5fab980a0826c18efa58ecd50e2c6">https://download.jetbrains.com/webide/PhpStorm-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="17">
+          <Date>2018-05-25</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Updated to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="16">
           <Date>2018-05-11</Date>
           <Version>2018.1.3</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="ed1dfe1b035cd47f16a6843c22481c1d10e1f805">https://download.jetbrains.com/ruby/RubyMine-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="66cba835c87e20641396b8316273d8712234a4cd">https://download.jetbrains.com/ruby/RubyMine-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="14">
+          <Date>2018-05-25</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Updated to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="13">
           <Date>2018-05-11</Date>
           <Version>2018.1.2</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.4892.44"
+Build = "181.5087.27"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="531881bc5760dfaf05e4d8888f89a4a9c3e4f1a9">https://download.jetbrains.com/webstorm/WebStorm-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="fefec3422ce2b4a3a67bf1cec86deb6e650ced9d">https://download.jetbrains.com/webstorm/WebStorm-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="15">
+          <Date>2018-05-25</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Updated to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="14">
           <Date>2018-05-11</Date>
           <Version>2018.1.3</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 20.

Updating:
- CLion to version 2018.1.3
- DataGrip to version 2018.1.4
- Idea to version 2018.1.4
- PhpStorm to version 2018.1.4
- RubyMine to version 2018.1.3
- WebStorm to version 2018.1.4

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com