### PR TITLE
Update JetBrains CW22

### DIFF
--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="3a36c8c268495a9dab832290bf407b06fa3c41d8">https://download.jetbrains.com/python/pycharm-community-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="7afb270850817613f5cfe35598050988d500b190">https://download.jetbrains.com/python/pycharm-community-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="13">
+          <Date>2018-06-01</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Updated to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
         <Update release="12">
           <Date>2018-05-18</Date>
           <Version>2018.1.3</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="3f97fd7424512347e00656eafadd5d5568d07a90">https://download.jetbrains.com/python/pycharm-professional-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="b4ce5487f65cea04e1bddec027b0f349309b72b3">https://download.jetbrains.com/python/pycharm-professional-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="16">
+          <Date>2018-06-01</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Updated to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+    </Update>
     <Update release="15">
           <Date>2018-05-18</Date>
           <Version>2018.1.3</Version>

--- a/programming/rider/pspec.xml
+++ b/programming/rider/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Summary>
         <Description xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Description>
-        <Archive type="targz" sha1sum="ce5b88b1f67f455baff925aa9d4e60f12d658961">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="1a22a35ecabea3815953206c6546856b5d251e04">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rider</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="4">
+          <Date>2018-06-01</Date>
+          <Version>2018.1.2</Version>
+          <Comment>Update to 2018.1.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="3">
           <Date>2018-04-20</Date>
           <Version>2018.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 20.

Updating:
- PyCharm to version 2018.1.4
- PyCharm-CE to version 2018.1.4
- Rider to version 2018.1.2

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com