### PR TITLE
Update GitKraken to 3.6.3

### DIFF
--- a/programming/gitkraken/pspec.xml
+++ b/programming/gitkraken/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>The downright luxurious Git client, for Windows, Mac and Linux</Summary>
         <Description>The downright luxurious Git client, for Windows, Mac and Linux</Description>
         <License>EULA</License>
-        <Archive sha1sum="fb91a4aff0005af493293c47fe9a59d033065e38" type="binary">https://release.gitkraken.com/linux/gitkraken-amd64.deb</Archive>
+        <Archive sha1sum="4a24108a3b689ce138d46b018eaf80eaf9451c2c" type="binary">https://release.gitkraken.com/linux/gitkraken-amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>libxscrnsaver</Dependency>
             <Dependency>gconf</Dependency>
@@ -35,6 +35,14 @@
     </Package>
 
     <History>
+        <Update release="50">
+            <Date>05-31-2018</Date>
+            <Version>3.6.3</Version>
+            <Comment>Update to 3.6.3</Comment>
+            <Name>Nícholas Lima de Souza Silva</Name>
+            <Email>nicholaslima.rw@gmail.com</Email>
+        </Update>
+		
         <Update release="49">
             <Date>05-30-2018</Date>
             <Version>3.6.2</Version>


### PR DESCRIPTION
This release addresses the git vulnerability that was recently identified in [CVE-2018-11235](https://nvd.nist.gov/vuln/detail/CVE-2018-11235).
