### PR TITLE
update plex media server to 1.13.2.5154

### DIFF
--- a/multimedia/video/plexmediaserver/pspec.xml
+++ b/multimedia/video/plexmediaserver/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Plex Media Server</Summary>
         <Description>Plex Media Server</Description>
         <License>Custom - https://plex.tv/legal</License>
-        <Archive sha1sum="d0ed422761cdf6c687460c4d03fdff6f2973931f" type="binary">https://downloads.plex.tv/plex-media-server/1.13.0.5023-31d3c0c65/plexmediaserver_1.13.0.5023-31d3c0c65_amd64.deb</Archive>
+        <Archive sha1sum="81ff7f8d80ac46ca663a54e09667ad47a2ccb1cd" type="binary">https://downloads.plex.tv/plex-media-server/1.13.2.5154-fd05be322/plexmediaserver_1.13.2.5154-fd05be322_amd64.deb</Archive>
 
         <BuildDependencies>
             <Dependency>binutils</Dependency>
@@ -33,6 +33,13 @@
     </Package>
 
     <History>
+        <Update release="15">
+            <Date>06-12-2018</Date>
+            <Version>1.13.2.5154</Version>
+            <Comment>Update to 1.13.2.5154</Comment>
+            <Name>Isaac Boehman</Name>
+            <Email>isaac@boehman.me</Email>
+        </Update>
         <Update release="14">
             <Date>05-17-2018</Date>
             <Version>1.13.0.5023</Version>


### PR DESCRIPTION
### changes

see title

### testing

Changed `BASE_URI` in my local [`eopkg_assist`](https://github.com/solus-project/solus-sc/blob/master/eopkg_assist/backend.py#L31) to point to my fork, then updated my local Plex Media Server to the newest version by running "Check for Updates" in the software center.

![screenshot from 2018-06-12 14-11-53](https://user-images.githubusercontent.com/4542094/41317635-ab655236-6e4a-11e8-9417-2553c9abee50.png)
