### PR TITLE
Update JetBrains CW24

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="c4387508393c5aa39c257fc054e1375617fb6fb4">https://download.jetbrains.com/cpp/CLion-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="c6d3a5d2b4bcd9d6d5fab15b549804bdea3055ea">https://download.jetbrains.com/cpp/CLion-2018.1.5.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -32,8 +32,8 @@
     <History>
         <Update release="15">
             <Date>2018-06-15</Date>
-            <Version>2018.1.4</Version>
-            <Comment>Update to 2018.1.4</Comment>
+            <Version>2018.1.5</Version>
+            <Comment>Update to 2018.1.5</Comment>
             <Name>ahahn94</Name>
             <Email>ahahn94@outlook.com</Email>
         </Update>

--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="fe75a3d81c6db3ef4a5fad2bd424d33b6688c621">https://download.jetbrains.com/cpp/CLion-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="c4387508393c5aa39c257fc054e1375617fb6fb4">https://download.jetbrains.com/cpp/CLion-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,55 +30,62 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="14">
-          <Date>2018-05-25</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Update to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="13">
-          <Date>2018-04-27</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Update to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="12">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Update to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="11">
-          <Date>2018-03-30</Date>
-          <Version>2018.1</Version>
-          <Comment>Update to 2018.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="10">
-          <Date>2018-03-09</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Update to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="9">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.3</Version>
-          <Comment>Update to 2017.3.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="8">
-          <Date>2017-12-02</Date>
-          <Version>2017.3</Version>
-          <Comment>Update to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="15">
+            <Date>2018-06-15</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Update to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2018-05-25</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Update to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="13">
+            <Date>2018-04-27</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Update to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="12">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Update to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-03-30</Date>
+            <Version>2018.1</Version>
+            <Comment>Update to 2018.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="10">
+            <Date>2018-03-09</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Update to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.3</Version>
+            <Comment>Update to 2017.3.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="8">
+            <Date>2017-12-02</Date>
+            <Version>2017.3</Version>
+            <Comment>Update to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="f0ce575a2d6cad22a0e66621b656e19fd11113ce" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.4-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="747dfa73ca0a56664c14467ff0b5abaf3fb56c83" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.5-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,69 +32,76 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="22">
-          <Date>2018-05-25</Date>
-          <Version>2018.1.4</Version>
-          <Comment>Updated to 2018.1.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="21">
-          <Date>2018-05-11</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Updated to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="20">
-          <Date>2018-04-27</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="19">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="18">
-          <Date>2018-03-30</Date>
-          <Version>2018.1</Version>
-          <Comment>Updated to 2018.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="17">
-          <Date>2018-03-16</Date>
-          <Version>2017.3.5</Version>
-          <Comment>Updated to 2017.3.5</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="16">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Updated to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="15">
-          <Date>2017-12-19</Date>
-          <Version>2017.3.1</Version>
-          <Comment>Updated to 2017.3.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="14">
-          <Date>2017-12-02</Date>
-          <Version>2017.3</Version>
-          <Comment>Updated to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="23">
+            <Date>2018-06-15</Date>
+            <Version>2018.1.5</Version>
+            <Comment>Updated to 2018.1.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="22">
+            <Date>2018-05-25</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="21">
+            <Date>2018-05-11</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Updated to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="20">
+            <Date>2018-04-27</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="19">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="18">
+            <Date>2018-03-30</Date>
+            <Version>2018.1</Version>
+            <Comment>Updated to 2018.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="17">
+            <Date>2018-03-16</Date>
+            <Version>2017.3.5</Version>
+            <Comment>Updated to 2017.3.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="16">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Updated to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="15">
+            <Date>2017-12-19</Date>
+            <Version>2017.3.1</Version>
+            <Comment>Updated to 2017.3.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2017-12-02</Date>
+            <Version>2017.3</Version>
+            <Comment>Updated to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="13">
             <Date>2017-10-02</Date>
             <Version>2017.2.5</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.5281.19"
+Build = "181.5281.35"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="6e1d9cddb1a1a5261c4b9e91d2bcf5009a592bc9">https://download.jetbrains.com/webide/PhpStorm-2018.1.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="e6632b5776bc58d270ff3549969d06a932b43d45">https://download.jetbrains.com/webide/PhpStorm-2018.1.6.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,76 +30,83 @@
         </RuntimeDependencies>
     </Package>
     <History>
-        <Update release="18">
-          <Date>2018-06-08</Date>
-          <Version>2018.1.5</Version>
-          <Comment>Updated to 2018.1.5</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
+        <Update release="19">
+            <Date>2018-06-15</Date>
+            <Version>2018.1.6</Version>
+            <Comment>Updated to 2018.1.6</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
         </Update>
-    <Update release="17">
-          <Date>2018-05-25</Date>
-          <Version>2018.1.4</Version>
-          <Comment>Updated to 2018.1.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="16">
-          <Date>2018-05-11</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Updated to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="15">
-          <Date>2018-04-27</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="14">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="13">
-          <Date>2018-03-30</Date>
-          <Version>2018.1</Version>
-          <Comment>Updated to 2018.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="12">
-          <Date>2018-03-16</Date>
-          <Version>2017.3.6</Version>
-          <Comment>Updated to 2017.3.6</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="11">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Updated to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="10">
-          <Date>2017-12-20</Date>
-          <Version>2017.3.1</Version>
-          <Comment>Updated to 2017.3.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="9">
-          <Date>2017-12-02</Date>
-          <Version>2017.3</Version>
-          <Comment>Updated to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="18">
+            <Date>2018-06-08</Date>
+            <Version>2018.1.5</Version>
+            <Comment>Updated to 2018.1.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="17">
+            <Date>2018-05-25</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="16">
+            <Date>2018-05-11</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Updated to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="15">
+            <Date>2018-04-27</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="13">
+            <Date>2018-03-30</Date>
+            <Version>2018.1</Version>
+            <Comment>Updated to 2018.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="12">
+            <Date>2018-03-16</Date>
+            <Version>2017.3.6</Version>
+            <Comment>Updated to 2017.3.6</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Updated to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="10">
+            <Date>2017-12-20</Date>
+            <Version>2017.3.1</Version>
+            <Comment>Updated to 2017.3.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2017-12-02</Date>
+            <Version>2017.3</Version>
+            <Comment>Updated to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="8">
             <Date>2017-10-01</Date>
             <Version>2017.2.4</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 24.

Updating:
- CLion to version ~~2018.1.4~~ 2018.1.5 (arrived only after opening the PR)
- Idea to version 2018.1.5
- PhpStorm to version 2018.1.6

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com