### PR TITLE
Update Enpass to the latest stable build 5.6.9

### DIFF
--- a/security/enpass/pspec.xml
+++ b/security/enpass/pspec.xml
@@ -11,7 +11,7 @@
         <Summary>A multiplatform password manager</Summary>
         <Description>A multiplatform password manager</Description>
         <License>Custom</License>
-        <Archive sha1sum="ae8583429a96ba58ca6eea1d5eb9968f3d9a0362" type="binary">http://repo.sinew.in/pool/main/e/enpass/enpass_5.6.5_amd64.deb</Archive>
+        <Archive sha1sum="b33964cbec179ab6cb614095260c2536341ab59d" type="binary">http://repo.sinew.in/pool/main/e/enpass/enpass_5.6.9_amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -29,6 +29,13 @@
     </Package>
 
     <History>
+        <Update release="8">
+            <Date>06-18-2018</Date>
+            <Version>5.6.9</Version>
+            <Comment>Update to 5.6.9</Comment>
+            <Name>James Lee</Name>
+            <Email>jamesl33info@gmail.com</Email>
+        </Update>
         <Update release="7">
             <Date>02-02-2018</Date>
             <Version>5.6.5</Version>


### PR DESCRIPTION
Update Enpass to version 5.6.9.

Updating:
* Enpass to version 5.6.9.

Tested:
Build, install and execution.