### PR TITLE
Update JetBrains CW25

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="7e5ddbe1ea3b74052372e300c7b8b0769bdce710">https://download.jetbrains.com/datagrip/datagrip-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="424ba637dbcb097dba9ab203c47c8776ac0d1723">https://download.jetbrains.com/datagrip/datagrip-2018.1.5.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,69 +30,76 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="17">
-          <Date>2018-05-25</Date>
-          <Version>2018.1.4</Version>
-          <Comment>Updated to 2018.1.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="16">
-          <Date>2018-05-04</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="15">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="14">
-          <Date>2018-03-02</Date>
-          <Version>2017.3.7</Version>
-          <Comment>Updated to 2017.3.7</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="13">
-          <Date>2018-02-23</Date>
-          <Version>2017.3.6</Version>
-          <Comment>Updated to 2017.3.6</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="12">
-          <Date>2018-02-16</Date>
-          <Version>2017.3.5</Version>
-          <Comment>Updated to 2017.3.5</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="11">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Updated to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="10">
-          <Date>2017-12-20</Date>
-          <Version>2017.3.3</Version>
-          <Comment>Updated to 2017.3.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="9">
-          <Date>2017-12-08</Date>
-          <Version>2017.3</Version>
-          <Comment>Updated to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="18">
+            <Date>2018-06-22</Date>
+            <Version>2018.1.5</Version>
+            <Comment>Updated to 2018.1.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="17">
+            <Date>2018-05-25</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="16">
+            <Date>2018-05-04</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="15">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2018-03-02</Date>
+            <Version>2017.3.7</Version>
+            <Comment>Updated to 2017.3.7</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="13">
+            <Date>2018-02-23</Date>
+            <Version>2017.3.6</Version>
+            <Comment>Updated to 2017.3.6</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="12">
+            <Date>2018-02-16</Date>
+            <Version>2017.3.5</Version>
+            <Comment>Updated to 2017.3.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Updated to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="10">
+            <Date>2017-12-20</Date>
+            <Version>2017.3.3</Version>
+            <Comment>Updated to 2017.3.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2017-12-08</Date>
+            <Version>2017.3</Version>
+            <Comment>Updated to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="8">
             <Date>2017-10-01</Date>
             <Version>2017.2.2</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.5087.27"
+Build = "181.5281.31"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="fefec3422ce2b4a3a67bf1cec86deb6e650ced9d">https://download.jetbrains.com/webstorm/WebStorm-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="e793bf5a6c5998f05b233ad2ce78d8a85a6f3092">https://download.jetbrains.com/webstorm/WebStorm-2018.1.5.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+    <Update release="16">
+          <Date>2018-06-22</Date>
+          <Version>2018.1.5</Version>
+          <Comment>Updated to 2018.1.5</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
     <Update release="15">
           <Date>2018-05-25</Date>
           <Version>2018.1.4</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 25.

Updating:
- DataGrip to version 2018.1.5
- WebStorm to version 2018.1.5

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com