### PR TITLE
Update JetBrains CW26

### DIFF
--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="66cba835c87e20641396b8316273d8712234a4cd">https://download.jetbrains.com/ruby/RubyMine-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="3fc606e93df6eb7f287d78a9a551c01f55200336">https://download.jetbrains.com/ruby/RubyMine-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,55 +30,62 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="14">
-          <Date>2018-05-25</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Updated to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="13">
-          <Date>2018-05-11</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="15">
+            <Date>2018-06-29</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2018-05-25</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Updated to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="13">
+            <Date>2018-05-11</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="12">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="11">
-          <Date>2018-03-02</Date>
-          <Version>2017.3.3</Version>
-          <Comment>Updated to 2017.3.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-03-02</Date>
+            <Version>2017.3.3</Version>
+            <Comment>Updated to 2017.3.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
         </Update>
         <Update release="10">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.2</Version>
-          <Comment>Updated to 2017.3.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="9">
-          <Date>2017-12-02</Date>
-          <Version>2017.3</Version>
-          <Comment>Updated to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="8">
-          <Date>2017-08-11</Date>
-          <Version>2017.2.1</Version>
-          <Comment>Updated to 2017.2.1</Comment>
-          <Name>Silke Hofstra</Name>
-          <Email>silke@slxh.eu</Email>
-      </Update>
+            <Date>2018-02-02</Date>
+            <Version>2017.3.2</Version>
+            <Comment>Updated to 2017.3.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2017-12-02</Date>
+            <Version>2017.3</Version>
+            <Comment>Updated to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="8">
+            <Date>2017-08-11</Date>
+            <Version>2017.2.1</Version>
+            <Comment>Updated to 2017.2.1</Comment>
+            <Name>Silke Hofstra</Name>
+            <Email>silke@slxh.eu</Email>
+        </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 26.

Updating:
- RubyMine to version 2018.1.4

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com