### PR TITLE
Update JetBrains CW27

### DIFF
--- a/programming/rider/pspec.xml
+++ b/programming/rider/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Summary>
         <Description xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Description>
-        <Archive type="targz" sha1sum="1a22a35ecabea3815953206c6546856b5d251e04">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="8ac22343e1e21db4ee8d4c4e81bc7adbf56775e6">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rider</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="5">
+          <Date>2018-07-06</Date>
+          <Version>2018.1.3</Version>
+          <Comment>Update to 2018.1.3</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="4">
           <Date>2018-06-01</Date>
           <Version>2018.1.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 27.

Updating:
- Rider to version 2018.1.3

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com