### PR TITLE
Update JetBrains CW28

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="c6d3a5d2b4bcd9d6d5fab15b549804bdea3055ea">https://download.jetbrains.com/cpp/CLion-2018.1.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="d407f437501654b3b06a2fa430a9cbdf96faf2d4">https://download.jetbrains.com/cpp/CLion-2018.1.6.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="16">
+            <Date>2018-07-13</Date>
+            <Version>2018.1.6</Version>
+            <Comment>Update to 2018.1.6</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="15">
             <Date>2018-06-15</Date>
             <Version>2018.1.5</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="747dfa73ca0a56664c14467ff0b5abaf3fb56c83" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.5-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="8a68333261b1c66803935b600f37729d0ce85d20" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.6-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="24">
+            <Date>2018-07-13</Date>
+            <Version>2018.1.6</Version>
+            <Comment>Updated to 2018.1.6</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="23">
             <Date>2018-06-15</Date>
             <Version>2018.1.5</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 28.

Updating:
- CLion to version 2018.1.6
- Idea to version 2018.1.6

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com