### PR TITLE
Update Skype to version 8.26.0.70

### DIFF
--- a/network/im/skype/pspec.xml
+++ b/network/im/skype/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Skype keeps the world talking, for free.</Summary>
         <Description>Skype keeps you together. Call, message and share with others.</Description>
         <License>Copyright (c) 2017 Skype and/or Microsoft</License>
-        <Archive sha1sum="0aea90275ab546734473bdaaa46dbb3e42e243b5" type="binary">https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.18.0.6_amd64.deb</Archive>
+        <Archive sha1sum="8464a32f708d826b27a55c81a225ac3062f0eb99" type="binary">https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.26.0.70_amd64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -35,6 +35,14 @@
     </Package>
     
     <History>
+        <Update release="48">
+            <Date>07-21-2018</Date>
+            <Version>8.26.0.70</Version>
+            <Comment>Update to 8.26.0.70</Comment>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
+        </Update>
+        
         <Update release="47">
             <Date>05-25-2018</Date>
             <Version>8.18.0.6</Version>


### PR DESCRIPTION
The previous version is no longer available from their repository, so the current Third Party installation fails. This means we are forced to update to a version with that weird tray icon issue (see issue #352), but at least it'll work again (plus we're finally on a recent version again and can update every time a new stable one is released)