### PR TITLE
Update ocenaudio to version 3.4.3

### DIFF
--- a/multimedia/music/ocenaudio/pspec.xml
+++ b/multimedia/music/ocenaudio/pspec.xml
@@ -10,7 +10,7 @@
         <Summary>Ocenaudio is a fast, cross-platform audio editor.</Summary>
         <Description>Ocenaudio is a fast, cross-platform audio editor.</Description>
         <License>Proprietary</License>
-        <Archive sha1sum="fd8dfd94fa041098540636b8f5c352c49669240f" type="binary">https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian64.deb</Archive>
+        <Archive sha1sum="c24f634413622581cc9fb85d1fc6c44415fc18c6" type="binary">https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian64.deb</Archive>
         <BuildDependencies>
             <Dependency>binutils</Dependency>
         </BuildDependencies>
@@ -32,6 +32,14 @@
     </Package>
 
     <History>
+        <Update release="13">
+            <Date>07-22-2018</Date>
+            <Version>3.4.3</Version>
+            <Comment>Update to 3.4.3</Comment>
+            <Name>Thomas Staudinger</Name>
+            <Email>Staudi.Kaos@gmail.com</Email>
+        </Update>
+        
         <Update release="12">
             <Date>02-07-2018</Date>
             <Version>3.3.10</Version>


### PR DESCRIPTION
File behind the link, and thus the hash, changed, so the old version doesn't work anymore.