### PR TITLE
Update JetBrains CW30

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="d407f437501654b3b06a2fa430a9cbdf96faf2d4">https://download.jetbrains.com/cpp/CLion-2018.1.6.tar.gz</Archive>
+        <Archive type="targz" sha1sum="78d45b6e0b5905c63deea6e391155f3342f73f36">https://download.jetbrains.com/cpp/CLion-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="17">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Update to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="16">
             <Date>2018-07-13</Date>
             <Version>2018.1.6</Version>

--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="424ba637dbcb097dba9ab203c47c8776ac0d1723">https://download.jetbrains.com/datagrip/datagrip-2018.1.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="8e8f2d3eb65bcfacd0a3793ae482e1a088afcbd1">https://download.jetbrains.com/datagrip/datagrip-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="19">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="18">
             <Date>2018-06-22</Date>
             <Version>2018.1.5</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="8a68333261b1c66803935b600f37729d0ce85d20" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.1.6-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="3b4c3ee14af2044212fd62d958b0b70b07230e61" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -33,9 +33,9 @@
     </Package>
     <History>
         <Update release="24">
-            <Date>2018-07-13</Date>
-            <Version>2018.1.6</Version>
-            <Comment>Updated to 2018.1.6</Comment>
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
             <Name>ahahn94</Name>
             <Email>ahahn94@outlook.com</Email>
         </Update>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.5281.35"
+Build = "182.3684.42"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="e6632b5776bc58d270ff3549969d06a932b43d45">https://download.jetbrains.com/webide/PhpStorm-2018.1.6.tar.gz</Archive>
+        <Archive type="targz" sha1sum="be55d1a97eee78b4371c1450b6f3d071ea83a821">https://download.jetbrains.com/webide/PhpStorm-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="20">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="19">
             <Date>2018-06-15</Date>
             <Version>2018.1.6</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="7afb270850817613f5cfe35598050988d500b190">https://download.jetbrains.com/python/pycharm-community-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="b2af4d31b0b902a307f62091a85386f8276e608f">https://download.jetbrains.com/python/pycharm-community-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,62 +30,69 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="14">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="13">
-          <Date>2018-06-01</Date>
-          <Version>2018.1.4</Version>
-          <Comment>Updated to 2018.1.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+            <Date>2018-06-01</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="12">
-          <Date>2018-05-18</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Updated to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="11">
-          <Date>2018-04-27</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="10">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="9">
-          <Date>2018-03-30</Date>
-          <Version>2018.1</Version>
-          <Comment>Updated to 2018.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="8">
-          <Date>2018-03-09</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Updated to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="7">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.3</Version>
-          <Comment>Updated to 2017.3.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="6">
-          <Date>2017-12-20</Date>
-          <Version>2017.3.1</Version>
-          <Comment>Updated to 2017.3.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+            <Date>2018-05-18</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Updated to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-04-27</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="10">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2018-03-30</Date>
+            <Version>2018.1</Version>
+            <Comment>Updated to 2018.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="8">
+            <Date>2018-03-09</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Updated to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="7">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.3</Version>
+            <Comment>Updated to 2017.3.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="6">
+            <Date>2017-12-20</Date>
+            <Version>2017.3.1</Version>
+            <Comment>Updated to 2017.3.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="5">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="b4ce5487f65cea04e1bddec027b0f349309b72b3">https://download.jetbrains.com/python/pycharm-professional-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="28ba058337896f07771b6824ff8bd8f974dc5418">https://download.jetbrains.com/python/pycharm-professional-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,69 +30,76 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="16">
-          <Date>2018-06-01</Date>
-          <Version>2018.1.4</Version>
-          <Comment>Updated to 2018.1.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-    </Update>
-    <Update release="15">
-          <Date>2018-05-18</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Updated to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-    </Update>
-    <Update release="14">
-          <Date>2018-04-27</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-    </Update>
-    <Update release="13">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-    </Update>
-    <Update release="12">
-          <Date>2018-03-30</Date>
-          <Version>2018.1</Version>
-          <Comment>Updated to 2018.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-    </Update>
-    <Update release="11">
-          <Date>2018-03-09</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Updated to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="10">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.3</Version>
-          <Comment>Updated to 2017.3.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="9">
-          <Date>2017-12-20</Date>
-          <Version>2017.3.1</Version>
-          <Comment>Updated to 2017.3.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="8">
-          <Date>2017-12-02</Date>
-          <Version>2017.3</Version>
-          <Comment>Updated to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="17">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="16">
+            <Date>2018-06-01</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="15">
+            <Date>2018-05-18</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Updated to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2018-04-27</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="13">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="12">
+            <Date>2018-03-30</Date>
+            <Version>2018.1</Version>
+            <Comment>Updated to 2018.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-03-09</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Updated to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="10">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.3</Version>
+            <Comment>Updated to 2017.3.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2017-12-20</Date>
+            <Version>2017.3.1</Version>
+            <Comment>Updated to 2017.3.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="8">
+            <Date>2017-12-02</Date>
+            <Version>2017.3</Version>
+            <Comment>Updated to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="3fc606e93df6eb7f287d78a9a551c01f55200336">https://download.jetbrains.com/ruby/RubyMine-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="4d08d7d1876f30914b222f67eaec2a185010bf60">https://download.jetbrains.com/ruby/RubyMine-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="16">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="15">
             <Date>2018-06-29</Date>
             <Version>2018.1.4</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "181.5281.31"
+Build = "182.3684.70"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="e793bf5a6c5998f05b233ad2ce78d8a85a6f3092">https://download.jetbrains.com/webstorm/WebStorm-2018.1.5.tar.gz</Archive>
+        <Archive type="targz" sha1sum="140af55c2a0cac3b83c5f1aefbf123fe1c70cb05">https://download.jetbrains.com/webstorm/WebStorm-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,76 +30,83 @@
         </RuntimeDependencies>
     </Package>
     <History>
-    <Update release="16">
-          <Date>2018-06-22</Date>
-          <Version>2018.1.5</Version>
-          <Comment>Updated to 2018.1.5</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="15">
-          <Date>2018-05-25</Date>
-          <Version>2018.1.4</Version>
-          <Comment>Updated to 2018.1.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="14">
-          <Date>2018-05-11</Date>
-          <Version>2018.1.3</Version>
-          <Comment>Updated to 2018.1.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="13">
-          <Date>2018-04-27</Date>
-          <Version>2018.1.2</Version>
-          <Comment>Updated to 2018.1.2</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="12">
-          <Date>2018-04-13</Date>
-          <Version>2018.1.1</Version>
-          <Comment>Updated to 2018.1.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="11">
-          <Date>2018-03-30</Date>
-          <Version>2018.1</Version>
-          <Comment>Updated to 2018.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-    <Update release="11">
-          <Date>2018-03-09</Date>
-          <Version>2017.3.5</Version>
-          <Comment>Updated to 2017.3.5</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="10">
-          <Date>2018-02-02</Date>
-          <Version>2017.3.4</Version>
-          <Comment>Updated to 2017.3.4</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="9">
-          <Date>2017-12-20</Date>
-          <Version>2017.3.1</Version>
-          <Comment>Updated to 2017.3.1</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
-      <Update release="8">
-          <Date>2017-12-02</Date>
-          <Version>2017.3</Version>
-          <Comment>Updated to 2017.3</Comment>
-          <Name>ahahn94</Name>
-          <Email>ahahn94@outlook.com</Email>
-      </Update>
+        <Update release="17">
+            <Date>2018-07-27</Date>
+            <Version>2018.2</Version>
+            <Comment>Updated to 2018.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="16">
+            <Date>2018-06-22</Date>
+            <Version>2018.1.5</Version>
+            <Comment>Updated to 2018.1.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="15">
+            <Date>2018-05-25</Date>
+            <Version>2018.1.4</Version>
+            <Comment>Updated to 2018.1.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="14">
+            <Date>2018-05-11</Date>
+            <Version>2018.1.3</Version>
+            <Comment>Updated to 2018.1.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="13">
+            <Date>2018-04-27</Date>
+            <Version>2018.1.2</Version>
+            <Comment>Updated to 2018.1.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="12">
+            <Date>2018-04-13</Date>
+            <Version>2018.1.1</Version>
+            <Comment>Updated to 2018.1.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-03-30</Date>
+            <Version>2018.1</Version>
+            <Comment>Updated to 2018.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="11">
+            <Date>2018-03-09</Date>
+            <Version>2017.3.5</Version>
+            <Comment>Updated to 2017.3.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="10">
+            <Date>2018-02-02</Date>
+            <Version>2017.3.4</Version>
+            <Comment>Updated to 2017.3.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="9">
+            <Date>2017-12-20</Date>
+            <Version>2017.3.1</Version>
+            <Comment>Updated to 2017.3.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
+        <Update release="8">
+            <Date>2017-12-02</Date>
+            <Version>2017.3</Version>
+            <Comment>Updated to 2017.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="7">
             <Date>2017-07-27</Date>
             <Version>2017.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 30.

Updating:
- CLion to version 2018.2
- DataGrip to version 2018.2
- Idea to version 2018.2
- PhpStorm to version 2018.2
- PyCharm to version 2018.2
- PyCharm-CE to version 2018.2
- RubyMine to version 2018.2
- WebStorm to version 2018.2

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com