### PR TITLE
Update JetBrains CW31

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="8e8f2d3eb65bcfacd0a3793ae482e1a088afcbd1">https://download.jetbrains.com/datagrip/datagrip-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="c7c897678b48a3fa1e21a4f9e7067a3b9faaf6f4">https://download.jetbrains.com/datagrip/datagrip-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="20">
+            <Date>2018-08-03</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="19">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/rider/pspec.xml
+++ b/programming/rider/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Summary>
         <Description xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Description>
-        <Archive type="targz" sha1sum="8ac22343e1e21db4ee8d4c4e81bc7adbf56775e6">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.3.tar.gz</Archive>
+        <Archive type="targz" sha1sum="2fee63ca922c8b6fef35a810916c63045873f67f">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rider</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="6">
+          <Date>2018-08-03</Date>
+          <Version>2018.1.4</Version>
+          <Comment>Update to 2018.1.4</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="5">
           <Date>2018-07-06</Date>
           <Version>2018.1.3</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 31.

Updating:
- DataGrip 2018.2.1
- Rider 2018.1.4

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com