### PR TITLE
Update jet brains cw32

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="78d45b6e0b5905c63deea6e391155f3342f73f36">https://download.jetbrains.com/cpp/CLion-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="041630454db462ff3f6f157ff13a7fcaeeae55c5">https://download.jetbrains.com/cpp/CLion-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="18">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Update to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="17">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="3b4c3ee14af2044212fd62d958b0b70b07230e61" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="13e8c2a33b2cf7d03aa7992aa8e35c42cfc6d873" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.1-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="26">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="25">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "182.3684.42"
+Build = "182.3911.43"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="be55d1a97eee78b4371c1450b6f3d071ea83a821">https://download.jetbrains.com/webide/PhpStorm-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="6446220d1be5fbf9bcb3102a2aef6b4cc5c203a3">https://download.jetbrains.com/webide/PhpStorm-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="21">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="20">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="b2af4d31b0b902a307f62091a85386f8276e608f">https://download.jetbrains.com/python/pycharm-community-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="eeb88867b3b71639b452f5468b250308f99ed1cb">https://download.jetbrains.com/python/pycharm-community-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="15">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="14">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="28ba058337896f07771b6824ff8bd8f974dc5418">https://download.jetbrains.com/python/pycharm-professional-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="5a5b5807a053b1fc076aa115e321cbb68a62f14c">https://download.jetbrains.com/python/pycharm-professional-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="18">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="17">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="4d08d7d1876f30914b222f67eaec2a185010bf60">https://download.jetbrains.com/ruby/RubyMine-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="548160164eb213cf360cce5a3006033c0cb403f9">https://download.jetbrains.com/ruby/RubyMine-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="17">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="16">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "182.3684.70"
+Build = "182.3911.37"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="140af55c2a0cac3b83c5f1aefbf123fe1c70cb05">https://download.jetbrains.com/webstorm/WebStorm-2018.2.tar.gz</Archive>
+        <Archive type="targz" sha1sum="44c105acec20b43d0973c1476ca28666326e7918">https://download.jetbrains.com/webstorm/WebStorm-2018.2.1.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="18">
+            <Date>2018-08-10</Date>
+            <Version>2018.2.1</Version>
+            <Comment>Updated to 2018.2.1</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="17">
             <Date>2018-07-27</Date>
             <Version>2018.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 32.

Updating:
- CLion to version 2018.2.1
- Idea to version 2018.2.1
- PyCharm to version 2018.2.1
- PyCharm-CE to version 2018.2.1
- PhpStorm to version 2018.2.1
- RubyMine to version 2018.2.1
- WebStorm to version 2018.2.1

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com