### PR TITLE
Update JetBrains CW33

### DIFF
--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="c7c897678b48a3fa1e21a4f9e7067a3b9faaf6f4">https://download.jetbrains.com/datagrip/datagrip-2018.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="e6216cfb53ed2250b96da3c7eaade74382daf5cf">https://download.jetbrains.com/datagrip/datagrip-2018.2.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="21">
+            <Date>2018-08-17</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Updated to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="20">
             <Date>2018-08-03</Date>
             <Version>2018.2.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 33.

Updating:
- DataGrip to version 2018.2.2

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com