### PR TITLE
Update JetBrains CW34

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="041630454db462ff3f6f157ff13a7fcaeeae55c5">https://download.jetbrains.com/cpp/CLion-2018.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="1e8b1f8d666e0ec2e343688d2159bc1fe7ab3afb">https://download.jetbrains.com/cpp/CLion-2018.2.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="19">
+            <Date>2018-08-24</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Update to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="18">
             <Date>2018-08-10</Date>
             <Version>2018.2.1</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -12,7 +12,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="13e8c2a33b2cf7d03aa7992aa8e35c42cfc6d873" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.1-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="8153febfbf58f431fddefd0d8f82da2f9383c74e" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.2-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +32,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="27">
+            <Date>2018-08-24</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Updated to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="26">
             <Date>2018-08-10</Date>
             <Version>2018.2.1</Version>

--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "182.3911.43"
+Build = "182.4129.45"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive type="targz" sha1sum="6446220d1be5fbf9bcb3102a2aef6b4cc5c203a3">https://download.jetbrains.com/webide/PhpStorm-2018.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="785979e171bc4e72bf236368fee802fef165f3d1">https://download.jetbrains.com/webide/PhpStorm-2018.2.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="22">
+            <Date>2018-08-24</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Updated to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="21">
             <Date>2018-08-10</Date>
             <Version>2018.2.1</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="eeb88867b3b71639b452f5468b250308f99ed1cb">https://download.jetbrains.com/python/pycharm-community-2018.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="b44ae6fd43b22b437d4f5e4cca900b8fff322a71">https://download.jetbrains.com/python/pycharm-community-2018.2.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="16">
+            <Date>2018-08-24</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Updated to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="15">
             <Date>2018-08-10</Date>
             <Version>2018.2.1</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="5a5b5807a053b1fc076aa115e321cbb68a62f14c">https://download.jetbrains.com/python/pycharm-professional-2018.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="43aa1358ca95740e324122741d6d6e3074427435">https://download.jetbrains.com/python/pycharm-professional-2018.2.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="19">
+            <Date>2018-08-24</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Updated to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="18">
             <Date>2018-08-10</Date>
             <Version>2018.2.1</Version>

--- a/programming/rider/pspec.xml
+++ b/programming/rider/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Summary>
         <Description xml:lang="en">Rider - A cross-platform .NET IDE based on the IntelliJ platform and ReSharper</Description>
-        <Archive type="targz" sha1sum="2fee63ca922c8b6fef35a810916c63045873f67f">https://download.jetbrains.com/rider/JetBrains.Rider-2018.1.4.tar.gz</Archive>
+        <Archive type="targz" sha1sum="b2a3c739bd675fb00e8aca3a1cec1fb5a6180836">https://download.jetbrains.com/rider/JetBrains.Rider-2018.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rider</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+      <Update release="7">
+          <Date>2018-08-24</Date>
+          <Version>2018.2</Version>
+          <Comment>Update to 2018.2</Comment>
+          <Name>ahahn94</Name>
+          <Email>ahahn94@outlook.com</Email>
+      </Update>
       <Update release="6">
           <Date>2018-08-03</Date>
           <Version>2018.1.4</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "182.3911.37"
+Build = "182.4129.32"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive type="targz" sha1sum="44c105acec20b43d0973c1476ca28666326e7918">https://download.jetbrains.com/webstorm/WebStorm-2018.2.1.tar.gz</Archive>
+        <Archive type="targz" sha1sum="8a20e30aae6a2a79a127c872a48729898e7eb1cb">https://download.jetbrains.com/webstorm/WebStorm-2018.2.2.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="19">
+            <Date>2018-08-24</Date>
+            <Version>2018.2.2</Version>
+            <Comment>Updated to 2018.2.2</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+        </Update>
         <Update release="18">
             <Date>2018-08-10</Date>
             <Version>2018.2.1</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 34.

Updating:
- CLion to version 2018.2.2
- Idea to version 2018.2.2
- PhpStorm to version 2018.2.2
- PyCharm to version 2018.2.2
- PyCharm-CE to version 2018.2.2
- Rider to version 2018.2
- WebStorm to version 2018.2.2

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com