### PR TITLE
Small fixes to TeamViewer

### DIFF
--- a/network/util/teamviewer/actions.py
+++ b/network/util/teamviewer/actions.py
@@ -6,7 +6,6 @@ from pisi.actionsapi import get, pisitools, shelltools
 
 Version = get.srcVERSION()
 WorkDir = "."
-NoStrip = ["/opt/teamviewer/tv_bin/wine/drive_c/TeamViewer/tvwine.dll.so"]
 IgnoreAutodep = True
 
 def build():

--- a/network/util/teamviewer/actions.py
+++ b/network/util/teamviewer/actions.py
@@ -28,5 +28,3 @@ def install():
 
     shelltools.chmod("%s/opt/teamviewer/doc/*" % get.installDIR(),0755)
     shelltools.chmod("%s/opt/teamviewer/tv_bin/*" % get.installDIR(),0755)
-    
-    # shelltools.system("systemctl start teamviewerd.service")

--- a/network/util/teamviewer/actions.py
+++ b/network/util/teamviewer/actions.py
@@ -21,7 +21,7 @@ def install():
     pisitools.dosym("/opt/teamviewer/tv_bin/script/teamviewer", "/usr/bin/teamviewer")
     pisitools.dosym("/opt/teamviewer/tv_bin/desktop/com.teamviewer.TeamViewer.desktop", "/usr/share/applications/teamviewer-teamviewer.desktop")
     pisitools.dosym("/etc/systemd/system/teamviewerd.service", "/etc/systemd/system/multi-user.target.wants/teamviewerd.service")    
-    pisitools.dosym("/opt/teamviewer/tv_bin/desktop/teamviewer.png", "/usr/share/pixmaps/teamviewer.png")
+    pisitools.dosym("/opt/teamviewer/tv_bin/desktop/teamviewer_256.png", "/usr/share/pixmaps/teamviewer.png")
 
     pisitools.dodir("/etc/teamviewer")
     pisitools.dodir("/var/log/teamviewer13")

--- a/network/util/teamviewer/actions.py
+++ b/network/util/teamviewer/actions.py
@@ -19,7 +19,7 @@ def install():
     
     #necessary symlinks
     pisitools.dosym("/opt/teamviewer/tv_bin/script/teamviewer", "/usr/bin/teamviewer")
-    pisitools.dosym("/opt/teamviewer/tv_bin/desktop/com.teamviewer.TeamViewer.desktop", "/usr/share/applications/teamviewer-teamviewer.desktop")
+    pisitools.dosym("/opt/teamviewer/tv_bin/desktop/com.teamviewer.TeamViewer.desktop", "/usr/share/applications/teamviewer.desktop")
     pisitools.dosym("/etc/systemd/system/teamviewerd.service", "/etc/systemd/system/multi-user.target.wants/teamviewerd.service")    
     pisitools.dosym("/opt/teamviewer/tv_bin/desktop/teamviewer_256.png", "/usr/share/pixmaps/teamviewer.png")
 

--- a/network/util/teamviewer/pspec.xml
+++ b/network/util/teamviewer/pspec.xml
@@ -64,6 +64,14 @@
     </Package>
 
     <History>
+        <Update release="13">
+            <Date>08-25-2018</Date>
+            <Version>13.2.13582</Version>
+            <Comment>Some small fixes to setup</Comment>
+            <Name>Thomas Staudinger</Name>
+            <Email>staudi.kaos@gmail.com</Email>
+        </Update>
+        
         <Update release="12">
             <Date>08-13-2018</Date>
             <Version>13.2.13582</Version>


### PR DESCRIPTION
Fixed icon name, desktop file name and removed obsolete reference to tvwine.dll now that TeamViewer is a native Qt app