### PR TITLE
Update JetBrains CW38

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive type="targz" sha1sum="98b03f37fc887d106f41e5f88a59baa2f415ef09">https://download.jetbrains.com/cpp/CLion-2018.2.3.tar.gz</Archive>
+        <Archive sha1sum="2af40a62eb5f86bf3e5ba5661c7717e23789c890" type="targz">https://download.jetbrains.com/cpp/CLion-2018.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="21">
+            <Date>2018-09-22</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="20">
             <Date>2018-09-07</Date>
             <Version>2018.2.3</Version>

--- a/programming/datagrip/pspec.xml
+++ b/programming/datagrip/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">DataGrip - an IDE for the SQL Language</Summary>
         <Description xml:lang="en">DataGrip - an IDE for the SQL Language</Description>
-        <Archive type="targz" sha1sum="96cad5aaac212406ac4fea16b274b437e3580172">https://download.jetbrains.com/datagrip/datagrip-2018.2.3.tar.gz</Archive>
+        <Archive sha1sum="1b7d59cc596e1c8e9d8e5072fbd312f8760a5529" type="targz">https://download.jetbrains.com/datagrip/datagrip-2018.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>datagrip</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="23">
+            <Date>2018-09-22</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="22">
             <Date>2018-09-07</Date>
             <Version>2018.2.3</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" ?>
-<!DOCTYPE PISI SYSTEM "https://solus-project.com/standard/pisi-spec.dtd">
 <PISI>
     <Source>
         <Name>idea</Name>
@@ -12,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="2cf3f8f4a57e5a2a89400188798a17516f103c8e" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.3-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="f0e80703cfe05c158e13cf5e41ef3240562ae1e6" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.4-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="29">
+            <Date>2018-09-22</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="28">
             <Date>2018-09-07</Date>
             <Version>2018.2.3</Version>

--- a/programming/pycharm-ce/pspec.xml
+++ b/programming/pycharm-ce/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm Community Edition - an IDE for the Python</Summary>
         <Description xml:lang="en">PyCharm Community Edition - an IDE for the Python</Description>
-        <Archive type="targz" sha1sum="9b6a08d16ce70ef4b0c4fc6aef70f736df5ab1cf">https://download.jetbrains.com/python/pycharm-community-2018.2.3.tar.gz</Archive>
+        <Archive sha1sum="0bf6a3fc4657ec3d251938a5a3666327bca7b918" type="targz">https://download.jetbrains.com/python/pycharm-community-2018.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm-ce</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="18">
+            <Date>2018-09-22</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="17">
             <Date>2018-09-07</Date>
             <Version>2018.2.3</Version>

--- a/programming/pycharm/pspec.xml
+++ b/programming/pycharm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PyCharm - an IDE for the Python Language</Summary>
         <Description xml:lang="en">PyCharm - an IDE for the Python Language</Description>
-        <Archive type="targz" sha1sum="8af6effbcd43439a88b6a20a017bfcc28f8d1146">https://download.jetbrains.com/python/pycharm-professional-2018.2.3.tar.gz</Archive>
+        <Archive sha1sum="6cb2646bfbcdc7e34dba14ce2c7ed979a7f37685" type="targz">https://download.jetbrains.com/python/pycharm-professional-2018.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>pycharm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="21">
+            <Date>2018-09-22</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="20">
             <Date>2018-09-07</Date>
             <Version>2018.2.3</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 38.

Updating:
- CLion to version 2018.2.4
- DataGrip to version 2018.2.4
- Idea to version 2018.2.4
- PyCharm to version 2018.2.4
- PyCharm-CE  to version 2018.2.4

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com