### PR TITLE
Update JetBrains CW39

### DIFF
--- a/programming/phpstorm/actions.py
+++ b/programming/phpstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "182.4323.68"
+Build = "182.4505.42"
 
 def install():
     shutil.rmtree("PhpStorm-%s/jre64" % Build)

--- a/programming/phpstorm/pspec.xml
+++ b/programming/phpstorm/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">PHPStorm - an IDE for the PHP Language</Summary>
         <Description xml:lang="en">PHPStorm - an IDE for the PHP Language</Description>
-        <Archive sha1sum="e3f8404f7064f98b081c6cf6715a4a1a7aacb4be" type="targz">https://download.jetbrains.com/webide/PhpStorm-2018.2.3.tar.gz</Archive>
+        <Archive sha1sum="336d29c2022428c5f4096daad30ba5c81a9381bd" type="targz">https://download.jetbrains.com/webide/PhpStorm-2018.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>phpstorm</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="24">
+            <Date>2018-09-29</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="23">
             <Date>2018-09-15</Date>
             <Version>2018.2.3</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -10,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive type="targz" sha1sum="541b095400b1dc4dcd83e334a73c1d7ea694a6df">https://download.jetbrains.com/ruby/RubyMine-2018.2.2.tar.gz</Archive>
+        <Archive sha1sum="06235f6c28e55cca8d04b62493fc2e0aca1201bf" type="targz">https://download.jetbrains.com/ruby/RubyMine-2018.2.3.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -30,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="19">
+            <Date>2018-09-29</Date>
+            <Version>2018.2.3</Version>
+            <Comment>Updated to 2018.2.3</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="18">
             <Date>2018-08-31</Date>
             <Version>2018.2.2</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 39.

Updating:
- PhpStorm to version 2018.2.4
- RubyMine to version 2018.2.3

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com