### PR TITLE
Update JetBrains CW42

### DIFF
--- a/programming/clion/pspec.xml
+++ b/programming/clion/pspec.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" ?>
-<!DOCTYPE PISI SYSTEM "https://getsol.us/standard/pisi-spec.dtd">
 <PISI>
     <Source>
         <Name>clion</Name>
@@ -12,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">CLion - an IDE for the C Language</Summary>
         <Description xml:lang="en">CLion - an IDE for the C Language</Description>
-        <Archive sha1sum="2af40a62eb5f86bf3e5ba5661c7717e23789c890" type="targz">https://download.jetbrains.com/cpp/CLion-2018.2.4.tar.gz</Archive>
+        <Archive sha1sum="19cec45a17f46033c05685804086f73104eaa76d" type="targz">https://download.jetbrains.com/cpp/CLion-2018.2.5.tar.gz</Archive>
     </Source>
     <Package>
         <Name>clion</Name>
@@ -32,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="22">
+            <Date>2018-10-20</Date>
+            <Version>2018.2.5</Version>
+            <Comment>Updated to 2018.2.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="21">
             <Date>2018-09-22</Date>
             <Version>2018.2.4</Version>

--- a/programming/idea/pspec.xml
+++ b/programming/idea/pspec.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" ?>
-<!DOCTYPE PISI SYSTEM "https://getsol.us/standard/pisi-spec.dtd">
 <PISI>
     <Source>
         <Name>idea</Name>
@@ -12,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">Idea - an IDE for the JVM Languages</Summary>
         <Description xml:lang="en">Idea - an IDE for the JVM Languages</Description>
-        <Archive sha1sum="f0e80703cfe05c158e13cf5e41ef3240562ae1e6" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.4-no-jdk.tar.gz</Archive>
+        <Archive sha1sum="bfb5d0d0e2748567b1b58deb2b05b315297b026a" type="targz">https://download.jetbrains.com/idea/ideaIU-2018.2.5-no-jdk.tar.gz</Archive>
     </Source>
     <Package>
         <Name>idea</Name>
@@ -32,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="30">
+            <Date>2018-10-20</Date>
+            <Version>2018.2.5</Version>
+            <Comment>Updated to 2018.2.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="29">
             <Date>2018-09-22</Date>
             <Version>2018.2.4</Version>

--- a/programming/rubymine/pspec.xml
+++ b/programming/rubymine/pspec.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" ?>
-<!DOCTYPE PISI SYSTEM "https://getsol.us/standard/pisi-spec.dtd">
 <PISI>
     <Source>
         <Name>rubymine</Name>
@@ -12,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">RubyMine - an IDE for the Ruby Language</Summary>
         <Description xml:lang="en">RubyMine - an IDE for the Ruby Language</Description>
-        <Archive sha1sum="06235f6c28e55cca8d04b62493fc2e0aca1201bf" type="targz">https://download.jetbrains.com/ruby/RubyMine-2018.2.3.tar.gz</Archive>
+        <Archive sha1sum="b5fee3c9acf182be1c4f58c0a248c2dfbddbea4f" type="targz">https://download.jetbrains.com/ruby/RubyMine-2018.2.4.tar.gz</Archive>
     </Source>
     <Package>
         <Name>rubymine</Name>
@@ -32,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="20">
+            <Date>2018-10-20</Date>
+            <Version>2018.2.4</Version>
+            <Comment>Updated to 2018.2.4</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="19">
             <Date>2018-09-29</Date>
             <Version>2018.2.3</Version>

--- a/programming/webstorm/actions.py
+++ b/programming/webstorm/actions.py
@@ -4,7 +4,7 @@ from pisi.actionsapi import get, pisitools, shelltools
 import shutil
 
 WorkDir = "."
-Build = "182.4505.50"
+Build = "182.4892.25"
 
 def install():
     shutil.rmtree("WebStorm-%s/jre64" % Build)

--- a/programming/webstorm/pspec.xml
+++ b/programming/webstorm/pspec.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0" ?>
-<!DOCTYPE PISI SYSTEM "https://getsol.us/standard/pisi-spec.dtd">
 <PISI>
     <Source>
         <Name>webstorm</Name>
@@ -12,7 +10,7 @@
         <PartOf>programming</PartOf>
         <Summary xml:lang="en">WebStorm - an IDE for the Web</Summary>
         <Description xml:lang="en">WebStorm - an IDE for the Web</Description>
-        <Archive sha1sum="20da51ceb7450cefaa80720af386a62df82bb351" type="targz">https://download.jetbrains.com/webstorm/WebStorm-2018.2.4.tar.gz</Archive>
+        <Archive sha1sum="5a3d6441a04431fd96e56a1dd1e473fc30735b0e" type="targz">https://download.jetbrains.com/webstorm/WebStorm-2018.2.5.tar.gz</Archive>
     </Source>
     <Package>
         <Name>webstorm</Name>
@@ -32,6 +30,13 @@
         </RuntimeDependencies>
     </Package>
     <History>
+        <Update release="22">
+            <Date>2018-10-20</Date>
+            <Version>2018.2.5</Version>
+            <Comment>Updated to 2018.2.5</Comment>
+            <Name>ahahn94</Name>
+            <Email>ahahn94@outlook.com</Email>
+            </Update>
         <Update release="21">
             <Date>2018-10-06</Date>
             <Version>2018.2.4</Version>


### PR DESCRIPTION
Update of the JetBrains IDEs for calendar week 42.

Updating:
- CLion to version 2018.2.5
- Idea to version 2018.2.5
- RubyMine to version 2018.2.4
- WebStorm to version 2018.2.5

Everything else is still up to date.

Tested:
Build, install and execution.

Signed-off-by: ahahn94 ahahn94@outlook.com